### PR TITLE
修复工作日常图片上传接口

### DIFF
--- a/app/Http/Controllers/Api/Admin/WorkDailyImageController.php
+++ b/app/Http/Controllers/Api/Admin/WorkDailyImageController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Api\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class WorkDailyImageController extends Controller
+{
+    public function store(Request $request)
+    {
+        $request->validate([
+            'file' => ['required', 'file', 'mimetypes:image/jpeg,image/png,image/gif,image/webp', 'max:5120'],
+        ]);
+
+        $file = $request->file('file');
+        $extension = strtolower($file->getClientOriginalExtension());
+        if ($extension === '') {
+            $extension = match ($file->getMimeType()) {
+                'image/jpeg' => 'jpg',
+                'image/png' => 'png',
+                'image/gif' => 'gif',
+                'image/webp' => 'webp',
+                default => '',
+            };
+        }
+        $allowedExtensions = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
+
+        if (!in_array($extension, $allowedExtensions, true)) {
+            return response()->json(message('文件格式不正确', false));
+        }
+
+        $relativeDir = '/uploads/work-daily/' . date('Ymd');
+        $targetDir = public_path($relativeDir);
+
+        if (!is_dir($targetDir) && !mkdir($targetDir, 0755, true) && !is_dir($targetDir)) {
+            throw new \RuntimeException('上传目录创建失败');
+        }
+
+        $fileName = Str::uuid()->toString() . '.' . $extension;
+        $file->move($targetDir, $fileName);
+
+        $path = $relativeDir . '/' . $fileName;
+
+        return response()->json(message(MESSAGE_OK, true, [
+            'url' => url($path),
+            'path' => $path,
+        ]));
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,6 +20,7 @@ use App\Http\Controllers\Api\MiniProgram\ImageController;
 use App\Http\Controllers\Api\Admin\ServerPathController;
 use App\Http\Controllers\Api\Admin\InitModelController;
 use App\Http\Controllers\Api\Admin\WorkDailyLogController;
+use App\Http\Controllers\Api\Admin\WorkDailyImageController;
 use App\Http\Controllers\Api\Admin\WorkPlatformController;
 use App\Http\Controllers\Api\Admin\WorkDocController;
 use App\Http\Controllers\Api\Admin\WorkDocCategoryController;
@@ -309,6 +310,8 @@ Route::name('api')->group(function () {
             ->middleware('filter.process:' . WorkDailyLog::class);
         // 导入牛马日常
         Route::post('work-daily/import', [WorkDailyLogController::class, 'import'])->name('work-daily.import');
+        // 上传牛马日常图片
+        Route::post('work-daily/image', [WorkDailyImageController::class, 'store'])->name('work-daily.image.store');
         // 牛马日常详情
         Route::get('work-daily/{workDailyLog}', [WorkDailyLogController::class, 'info'])->name('work-daily.info');
         // 添加牛马日常

--- a/tests/Feature/Api/Admin/WorkDailyImageUploadTest.php
+++ b/tests/Feature/Api/Admin/WorkDailyImageUploadTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\Api\Admin;
+
+use App\Models\User\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Tests\TestCase;
+
+class WorkDailyImageUploadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private array $uploadedPaths = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->uploadedPaths as $path) {
+            $absolutePath = public_path($path);
+            if (is_file($absolutePath)) {
+                unlink($absolutePath);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_work_daily_image_can_be_uploaded_to_public_work_daily_directory(): void
+    {
+        $user = User::query()->create([
+            'username' => 'work_daily_image_user',
+            'email' => 'work-daily-image@example.com',
+            'phone' => '13800000000',
+            'password' => bcrypt('password'),
+            'status' => 1,
+        ]);
+
+        $token = auth('api')->login($user);
+
+        $response = $this
+            ->withHeader('Authorization', "Bearer {$token}")
+            ->post('/api/work-daily/image', [
+                'file' => UploadedFile::fake()->create('daily.png', 10, 'image/png'),
+            ]);
+
+        $path = $response->json('data.path');
+        $this->uploadedPaths[] = $path;
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('code', 0);
+
+        $this->assertStringStartsWith('/uploads/work-daily/' . date('Ymd') . '/', $path);
+        $this->assertStringContainsString('/uploads/work-daily/' . date('Ymd') . '/', $response->json('data.url'));
+        $this->assertFileExists(public_path($path));
+    }
+}


### PR DESCRIPTION
## 变更
- 新增工作日常图片上传接口，保存到 public/uploads/work-daily/YYYYMMDD
- 返回可访问图片 URL，供 Markdown 正文写入
- 增加接口 Feature 测试

## 原因
编辑页上传或粘贴图片后，正文需要保存真实图片地址，不能保存 mavon-editor 的本地占位符。

## 验证
- 远端执行 ./vendor/bin/sail artisan test tests/Feature/Api/Admin/WorkDailyImageUploadTest.php 通过