### PR TITLE
修复工作台当前连续计算(连续到昨天也计入)

### DIFF
--- a/app/Services/Api/Admin/Dashboard/StatsAggregator.php
+++ b/app/Services/Api/Admin/Dashboard/StatsAggregator.php
@@ -276,8 +276,11 @@ class StatsAggregator
             $previous = $date;
         }
 
+        // 最后一次写作是今天或昨天，连续都仍然有效：
+        // 昨天写过、今天还没写也应计入当前连续，不能直接归零
         $lastDate = end($dates);
-        if ($lastDate === $endDate) {
+        $yesterday = Carbon::parse($endDate)->subDay()->toDateString();
+        if ($lastDate === $endDate || $lastDate === $yesterday) {
             $currentStreak = 1;
             $currentDate = Carbon::parse($lastDate);
             while (in_array($currentDate->copy()->subDay()->toDateString(), $dates, true)) {

--- a/tests/Unit/Dashboard/StatsAggregatorTest.php
+++ b/tests/Unit/Dashboard/StatsAggregatorTest.php
@@ -11,7 +11,7 @@ use Tests\TestCase;
 
 class StatsAggregatorTest extends TestCase
 {
-    public function test_streak_今天没写但昨天有时_current_streak_为_0(): void
+    public function test_streak_昨天写过今天还没写_仍算连续(): void
     {
         $service = new StatsAggregator();
 
@@ -21,6 +21,36 @@ class StatsAggregatorTest extends TestCase
         $yesterday = Carbon::today('Asia/Shanghai')->subDay()->toDateString();
 
         [$currentStreak] = $method->invoke($service, [$yesterday], $today);
+
+        $this->assertSame(1, $currentStreak);
+    }
+
+    public function test_streak_连续两天写到昨天_当前连续为_2(): void
+    {
+        $service = new StatsAggregator();
+
+        $method = new ReflectionMethod($service, 'calculateStreaks');
+        $method->setAccessible(true);
+        $today = Carbon::today('Asia/Shanghai');
+        $yesterday = $today->copy()->subDay()->toDateString();
+        $dayBefore = $today->copy()->subDays(2)->toDateString();
+
+        [$currentStreak] = $method->invoke($service, [$dayBefore, $yesterday], $today->toDateString());
+
+        $this->assertSame(2, $currentStreak);
+    }
+
+    public function test_streak_最后写作早于昨天_当前连续归零(): void
+    {
+        $service = new StatsAggregator();
+
+        $method = new ReflectionMethod($service, 'calculateStreaks');
+        $method->setAccessible(true);
+        $today = Carbon::today('Asia/Shanghai');
+        $twoDaysAgo = $today->copy()->subDays(2)->toDateString();
+        $threeDaysAgo = $today->copy()->subDays(3)->toDateString();
+
+        [$currentStreak] = $method->invoke($service, [$threeDaysAgo, $twoDaysAgo], $today->toDateString());
 
         $this->assertSame(0, $currentStreak);
     }


### PR DESCRIPTION
## 问题
工作台「当前连续」即使连续写了多天,只要今天还没写就显示 0。

## 根因
`StatsAggregator::calculateStreaks` 仅当最后写作日 === 今天时才统计当前连续。

## 修复
最后写作日为今天**或昨天**都视为连续仍有效(昨天写过、今天还没写也计入)。

## 测试
- 原测试 `test_streak_今天没写但昨天有时_current_streak_为_0` 锁定了旧的归零行为,已改为正确意图,并补「连续两天到昨天=2」「早于昨天=0」边界用例
- 远端 Pest 全绿;真实数据 tinker 验证 current_streak 由 0 → 2