### PR TITLE
统一后台接口 Controller/Request 风格

### DIFF
--- a/app/Http/Controllers/Api/Admin/DashboardController.php
+++ b/app/Http/Controllers/Api/Admin/DashboardController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\Admin;
 
 use App\Http\Controllers\Api\Controller;
+use App\Http\Requests\Api\Admin\DashboardStatsRequest;
 use App\Models\Admin\WorkDailyLog;
 use App\Services\Api\Admin\Dashboard\DashboardCache;
 use Illuminate\Support\Facades\DB;
@@ -11,10 +12,20 @@ use App\Services\Api\Admin\Dashboard\PlatformBreakdown;
 use App\Services\Api\Admin\Dashboard\StatsAggregator;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 
 class DashboardController extends Controller
 {
+    /**
+     * 初始化工作台统计依赖。
+     *
+     * @param DashboardCache $dashboardCache
+     * @param StatsAggregator $statsAggregator
+     * @param HeatmapBuilder $heatmapBuilder
+     * @param PlatformBreakdown $platformBreakdown
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
     public function __construct(
         private readonly DashboardCache $dashboardCache,
         private readonly StatsAggregator $statsAggregator,
@@ -23,7 +34,15 @@ class DashboardController extends Controller
     ) {
     }
 
-    public function stats(Request $request): JsonResponse
+    /**
+     * 获取工作台统计。
+     *
+     * @param DashboardStatsRequest $request
+     * @return JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function stats(DashboardStatsRequest $request): JsonResponse
     {
         $user = auth('api')->user();
         if (!$user) {
@@ -32,14 +51,6 @@ class DashboardController extends Controller
 
         $view = $request->get('view', 'overview');
         $range = $request->get('range', 'all');
-
-        if (!in_array($view, ['overview', 'platform', 'hour', 'tag'], true)) {
-            return response()->json(['code' => 422, 'msg' => '参数错误：view', 'data' => null], 422);
-        }
-
-        if (!in_array($range, ['all', '30d', '7d', 'today'], true)) {
-            return response()->json(['code' => 422, 'msg' => '参数错误：range', 'data' => null], 422);
-        }
 
         $isManager = $this->isManager($user);
         [$response, $cacheHit] = $this->dashboardCache->remember($user->id, $isManager, $view, $range, function () use ($user, $isManager, $view, $range) {

--- a/app/Http/Controllers/Api/Admin/InitModelController.php
+++ b/app/Http/Controllers/Api/Admin/InitModelController.php
@@ -3,38 +3,44 @@
 namespace App\Http\Controllers\Api\Admin;
 
 use App\Http\Controllers\Api\Controller;
-use App\Http\Requests\Api\Admin\MenuRequest;
-use App\Http\Requests\Api\FormRequest;
+use App\Http\Requests\Api\Admin\InitModelRequest;
 use App\Http\Resources\BaseResource;
 use App\Models\Admin\InitModel;
 use App\Services\Api\Admin\InitModelService;
-use GuzzleHttp\Utils;
 
 class InitModelController extends Controller
 {
-    public function __construct()
+    /**
+     * 初始化模型初始化服务。
+     *
+     * @param InitModelService $initModelService
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function __construct(private readonly InitModelService $initModelService)
     {
         parent::__construct();
-        $this->service = new InitModelService();
     }
 
 
     /**
-     * 服务器路径列表 - 分页
+     * 模型初始化列表 - 分页
      *
-     * @param FormRequest $request
+     * @param InitModelRequest $request
      * @param InitModel $initModel
      * @return BaseResource
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/3/18 09:52
+     * @date 2026/5/26
      */
-    public function index(FormRequest $request, InitModel $initModel)
+    public function index(InitModelRequest $request, InitModel $initModel)
     {
         // 生成允许过滤字段数组
         $allowedFilters = $request->generateAllowedFilters($initModel->getRequestFilters());
 
         $config = [
-            'allowedFilters' => $allowedFilters
+            'allowedFilters' => $allowedFilters,
+            'perPage' => $request->perPage(),
         ];
         $initModels = $this->queryBuilder($initModel, true, $config);
 
@@ -42,7 +48,7 @@ class InitModelController extends Controller
     }
 
     /**
-     * 服务器路径详情
+     * 模型初始化详情
      *
      * @param InitModel $initModel
      * @return BaseResource
@@ -55,15 +61,15 @@ class InitModelController extends Controller
     }
 
     /**
-     * 添加服务器路径
+     * 添加模型初始化
      *
-     * @param MenuRequest $request
+     * @param InitModelRequest $request
      * @param InitModel $initModel
      * @return BaseResource
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/3/11 13:07
+     * @date 2026/5/26
      */
-    public function add(FormRequest $request, InitModel $initModel)
+    public function add(InitModelRequest $request, InitModel $initModel)
     {
         $data = $request->getSnakeRequest();
 
@@ -75,15 +81,15 @@ class InitModelController extends Controller
     }
 
     /**
-     * 编辑服务器路径
+     * 编辑模型初始化
      *
      * @param InitModel $initModel
-     * @param FormRequest $request
+     * @param InitModelRequest $request
      * @return BaseResource
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/3/11 13:08
+     * @date 2026/5/26
      */
-    public function edit(InitModel $initModel, FormRequest $request)
+    public function edit(InitModel $initModel, InitModelRequest $request)
     {
         $data = $request->getSnakeRequest();
 
@@ -95,25 +101,25 @@ class InitModelController extends Controller
     }
 
     /**
-     * 服务器路径转换
+     * 模型初始化转换
      *
      * @param InitModel $initModel
-     * @param FormRequest $request
+     * @param InitModelRequest $request
      * @return \Illuminate\Http\JsonResponse
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/4/28 13:24
+     * @date 2026/5/26
      */
-    public function convert(InitModel $initModel, FormRequest $request)
+    public function convert(InitModel $initModel, InitModelRequest $request)
     {
-        $data = $request->getSnakeRequest();
+        $data = $request->validated();
 
-        $initModels = $this->service->convert($initModel, $data['columns']);
+        $initModels = $this->initModelService->convert($initModel, $data['columns']);
 
         return response()->json($initModels);
     }
 
     /**
-     * 删除服务器路径
+     * 删除模型初始化
      *
      * @param InitModel $initModel
      * @return \Illuminate\Http\JsonResponse
@@ -130,21 +136,14 @@ class InitModelController extends Controller
     /**
      * 兼容旧版前端批量删除
      *
-     * @param FormRequest $request
+     * @param InitModelRequest $request
      * @return \Illuminate\Http\JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function batchDelete(FormRequest $request)
+    public function batchDelete(InitModelRequest $request)
     {
-        $data = $request->getSnakeRequest();
-        $ids = $data['id'] ?? [];
-        $ids = is_array($ids) ? $ids : [$ids];
-        $ids = array_values(array_filter($ids, static function ($id) {
-            return is_numeric($id);
-        }));
-
-        if (!empty($ids)) {
-            InitModel::query()->whereIn('id', $ids)->delete();
-        }
+        InitModel::query()->whereIn('id', $request->integerIds())->delete();
 
         return response()->json([]);
     }

--- a/app/Http/Controllers/Api/Admin/MenuController.php
+++ b/app/Http/Controllers/Api/Admin/MenuController.php
@@ -13,23 +13,30 @@ use Spatie\QueryBuilder\QueryBuilder;
 
 class MenuController extends Controller
 {
-    public function __construct()
+    /**
+     * 初始化菜单服务。
+     *
+     * @param MenuService $menuService
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function __construct(private readonly MenuService $menuService)
     {
         parent::__construct();
-        $this->service = new MenuService();
     }
 
 
     /**
      * 菜单列表 - 不分页
      *
-     * @param FormRequest $request
+     * @param MenuRequest $request
      * @param Menu $menu
      * @return BaseResource
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/3/18 09:52
+     * @date 2026/5/26
      */
-    public function index(FormRequest $request, Menu $menu)
+    public function index(MenuRequest $request, Menu $menu)
     {
         // 生成允许过滤字段数组
         $allowedFilters = $request->generateAllowedFilters($menu->getRequestFilters());
@@ -37,7 +44,7 @@ class MenuController extends Controller
         $menus = QueryBuilder::for($menu)
             ->allowedFilters($allowedFilters)->orderBy('sort')->get()->toArray();
 
-        return new BaseResource($menus);
+        return $this->resource($menus);
     }
 
     /**
@@ -152,12 +159,12 @@ class MenuController extends Controller
      * 编辑菜单
      *
      * @param Menu $menu
-     * @param FormRequest $request
+     * @param MenuRequest $request
      * @return BaseResource
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/3/11 13:08
+     * @date 2026/5/26
      */
-    public function edit(Menu $menu, FormRequest $request)
+    public function edit(Menu $menu, MenuRequest $request)
     {
         $data = $request->all();
 
@@ -215,7 +222,7 @@ class MenuController extends Controller
             DB::commit();
         }
 
-        return new BaseResource($menu);
+        return $this->resource($menu);
     }
 
     /**
@@ -229,7 +236,7 @@ class MenuController extends Controller
     public function delete(Menu $menu)
     {
         // 批量删除子级
-        $this->service->batchDeleteChildren($menu->children);
+        $this->menuService->batchDeleteChildren($menu->children);
 
         $menu->delete();
 
@@ -277,8 +284,8 @@ class MenuController extends Controller
         }
 
         // menuChildren替换成 children
-        $menus = $this->service->convertChildrenKey($menus);
+        $menus = $this->menuService->convertChildrenKey($menus);
 
-        return new BaseResource($menus);
+        return $this->resource($menus);
     }
 }

--- a/app/Http/Controllers/Api/Admin/RoleController.php
+++ b/app/Http/Controllers/Api/Admin/RoleController.php
@@ -12,16 +12,28 @@ use Spatie\QueryBuilder\QueryBuilder;
 
 class RoleController extends Controller
 {
-    public function index(FormRequest $request, Role $role)
+    /**
+     * 角色列表 - 分页。
+     *
+     * @param RoleRequest $request
+     * @param Role $role
+     * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function index(RoleRequest $request, Role $role)
     {
         // 生成允许过滤字段数组
         $allowedFilters = $request->generateAllowedFilters($role->getRequestFilters());
 
-        $roles = QueryBuilder::for($role)
-            ->allowedIncludes('users', 'menus')
-            ->allowedFilters($allowedFilters)->paginate();
+        $config = [
+            'includes' => ['users', 'menus'],
+            'allowedFilters' => $allowedFilters,
+            'perPage' => $request->perPage(),
+        ];
+        $roles = $this->queryBuilder($role, true, $config);
 
-        return BaseResource::collection($roles);
+        return $this->resource($roles, ['time' => true, 'collection' => true]);
     }
 
     /**
@@ -52,11 +64,10 @@ class RoleController extends Controller
      */
     public function status(RoleRequest $request, Role $role)
     {
-        $role = $role->find($request->get('id'));
         $role->status = $request->get('status');
         $role->edit();
 
-        return new BaseResource($role);
+        return $this->resource($role);
     }
 
     /**
@@ -84,12 +95,12 @@ class RoleController extends Controller
      * 编辑角色
      *
      * @param Role $role
-     * @param FormRequest $request
+     * @param RoleRequest $request
      * @return BaseResource
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/3/11 13:08
+     * @date 2026/5/26
      */
-    public function edit(Role $role, FormRequest $request)
+    public function edit(Role $role, RoleRequest $request)
     {
         $data = $request->getSnakeRequest();
 
@@ -97,7 +108,7 @@ class RoleController extends Controller
 
         $role->edit();
 
-        return new BaseResource($role);
+        return $this->resource($role);
     }
 
     /**
@@ -123,15 +134,14 @@ class RoleController extends Controller
     /**
      * 批量删除
      *
-     * @param FormRequest $request
+     * @param RoleRequest $request
      * @return \Illuminate\Http\JsonResponse
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/3/11 13:32
+     * @date 2026/5/26
      */
-    public function batchDelete(FormRequest $request, Role $role)
+    public function batchDelete(RoleRequest $request, Role $role)
     {
-        $ids = $request->get('id');
-        foreach($ids as $id) {
+        foreach($request->integerIds() as $id) {
             $this->delete($role->find($id));
         }
 
@@ -184,9 +194,9 @@ class RoleController extends Controller
      * @param FormRequest $request
      * @return \Illuminate\Http\JsonResponse
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/3/11 15:08
+     * @date 2026/5/26
      */
-    public function savePermissionList(Role $role, FormRequest $request)
+    public function savePermissionList(Role $role, RoleRequest $request)
     {
         // 清空角色下的所有权限
         $role->menus()->detach();

--- a/app/Http/Controllers/Api/Admin/ServerPathController.php
+++ b/app/Http/Controllers/Api/Admin/ServerPathController.php
@@ -3,41 +3,46 @@
 namespace App\Http\Controllers\Api\Admin;
 
 use App\Http\Controllers\Api\Controller;
-use App\Http\Requests\Api\Admin\MenuRequest;
-use App\Http\Requests\Api\FormRequest;
+use App\Http\Requests\Api\Admin\ServerPathRequest;
 use App\Http\Resources\BaseResource;
 use App\Models\Admin\ServerPath;
 use App\Services\Api\Admin\ServerPathService;
 use GuzzleHttp\Utils;
+use Spatie\QueryBuilder\QueryBuilder;
 
 class ServerPathController extends Controller
 {
-    public function __construct()
+    /**
+     * 初始化服务器路径服务。
+     *
+     * @param ServerPathService $serverPathService
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function __construct(private readonly ServerPathService $serverPathService)
     {
         parent::__construct();
-        $this->service = new ServerPathService();
     }
 
 
     /**
      * 服务器路径列表 - 分页
      *
-     * @param FormRequest $request
+     * @param ServerPathRequest $request
      * @param ServerPath $serverPath
      * @return BaseResource
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/3/18 09:52
+     * @date 2026/5/26
      */
-    public function index(FormRequest $request, ServerPath $serverPath)
+    public function index(ServerPathRequest $request, ServerPath $serverPath)
     {
-        // 生成允许过滤字段数组
         $allowedFilters = $request->generateAllowedFilters($serverPath->getRequestFilters());
 
-        $config = [
-            'allowedFilters' => $allowedFilters,
-            'orderBy' => [['sort' => 'asc']]
-        ];
-        $serverPaths = $this->queryBuilder($serverPath, true, $config);
+        $serverPaths = QueryBuilder::for($serverPath)
+            ->allowedFilters($allowedFilters)
+            ->orderBy('sort', 'asc')
+            ->paginate($request->perPage());
 
         return $this->resource($serverPaths, ['time' => true, 'collection' => true]);
     }
@@ -58,23 +63,15 @@ class ServerPathController extends Controller
     /**
      * 添加服务器路径
      *
-     * @param MenuRequest $request
+     * @param ServerPathRequest $request
      * @param ServerPath $serverPath
      * @return BaseResource
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/3/11 13:07
+     * @date 2026/5/26
      */
-    public function add(FormRequest $request, ServerPath $serverPath)
+    public function add(ServerPathRequest $request, ServerPath $serverPath)
     {
-        $data = $request->getSnakeRequest();
-
-        // 兼容前端未传 url/sort 的场景
-        $data['url'] = $data['url'] ?? '';
-        $data['sort'] = isset($data['sort']) ? (int)$data['sort'] : 0;
-
-        if (isset($data['sources']) && is_array($data['sources'])) {
-            $data['sources'] = Utils::jsonEncode($data['sources']);
-        }
+        $data = $this->normalizePayload($request);
 
         $serverPath->fill($data);
 
@@ -87,22 +84,14 @@ class ServerPathController extends Controller
      * 编辑服务器路径
      *
      * @param ServerPath $serverPath
-     * @param FormRequest $request
+     * @param ServerPathRequest $request
      * @return BaseResource
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/3/11 13:08
+     * @date 2026/5/26
      */
-    public function edit(ServerPath $serverPath, FormRequest $request)
+    public function edit(ServerPath $serverPath, ServerPathRequest $request)
     {
-        $data = $request->getSnakeRequest();
-
-        // 兼容前端未传 url/sort 的场景
-        $data['url'] = $data['url'] ?? ($serverPath->url ?? '');
-        $data['sort'] = isset($data['sort']) ? (int)$data['sort'] : ((int) $serverPath->sort);
-
-        if (isset($data['sources']) && is_array($data['sources'])) {
-            $data['sources'] = Utils::jsonEncode($data['sources']);
-        }
+        $data = $this->normalizePayload($request);
 
         $serverPath->fill($data);
 
@@ -115,16 +104,16 @@ class ServerPathController extends Controller
      * 服务器路径转换
      *
      * @param ServerPath $serverPath
-     * @param FormRequest $request
+     * @param ServerPathRequest $request
      * @return \Illuminate\Http\JsonResponse
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/4/28 13:24
+     * @date 2026/5/26
      */
-    public function convert(ServerPath $serverPath, FormRequest $request)
+    public function convert(ServerPath $serverPath, ServerPathRequest $request)
     {
-        $data = $request->getSnakeRequest();
+        $data = $request->validated();
 
-        $serverPaths = $this->service->convert($serverPath, $data['paths']);
+        $serverPaths = $this->serverPathService->convert($serverPath, $data['paths']);
 
         return response()->json($serverPaths);
     }
@@ -147,22 +136,33 @@ class ServerPathController extends Controller
     /**
      * 兼容旧版前端批量删除
      *
-     * @param FormRequest $request
+     * @param ServerPathRequest $request
      * @return \Illuminate\Http\JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function batchDelete(FormRequest $request)
+    public function batchDelete(ServerPathRequest $request)
     {
-        $data = $request->getSnakeRequest();
-        $ids = $data['id'] ?? [];
-        $ids = is_array($ids) ? $ids : [$ids];
-        $ids = array_values(array_filter($ids, static function ($id) {
-            return is_numeric($id);
-        }));
-
-        if (!empty($ids)) {
-            ServerPath::query()->whereIn('id', $ids)->delete();
-        }
+        ServerPath::query()->whereIn('id', $request->integerIds())->delete();
 
         return response()->json([]);
     }
+
+    /**
+     * 归一化服务器路径保存数据。
+     *
+     * @param ServerPathRequest $request
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    private function normalizePayload(ServerPathRequest $request): array
+    {
+        $data = $request->getSnakeRequest();
+        $data['sort'] = (int) $data['sort'];
+        $data['sources'] = Utils::jsonEncode($data['sources']);
+
+        return $data;
+    }
+
 }

--- a/app/Http/Controllers/Api/Admin/TodoItemController.php
+++ b/app/Http/Controllers/Api/Admin/TodoItemController.php
@@ -3,13 +3,22 @@
 namespace App\Http\Controllers\Api\Admin;
 
 use App\Http\Controllers\Api\Controller;
-use App\Http\Requests\Api\FormRequest;
+use App\Http\Requests\Api\Admin\TodoItemRequest;
 use App\Models\Admin\TodoItem;
 use Spatie\QueryBuilder\QueryBuilder;
 
 class TodoItemController extends Controller
 {
-    public function index(FormRequest $request, TodoItem $todoItem)
+    /**
+     * 待办列表 - 分页。
+     *
+     * @param TodoItemRequest $request
+     * @param TodoItem $todoItem
+     * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function index(TodoItemRequest $request, TodoItem $todoItem)
     {
         $allowedFilters = $request->generateAllowedFilters($todoItem->getRequestFilters());
 
@@ -37,11 +46,19 @@ class TodoItemController extends Controller
             ->orderBy('due_date', 'asc')
             ->orderBy('id', 'desc');
 
-        $items = $query->paginate($request->get('pageSize') ?? self::PER_PAGE);
+        $items = $query->paginate($request->perPage());
 
         return $this->resource($items, ['time' => true, 'collection' => true]);
     }
 
+    /**
+     * 待办详情。
+     *
+     * @param TodoItem $todoItem
+     * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
     public function info(TodoItem $todoItem)
     {
         $this->authorizeOwner($todoItem);
@@ -50,11 +67,18 @@ class TodoItemController extends Controller
         return $this->resource($todoItem, ['time' => true]);
     }
 
-    public function add(FormRequest $request, TodoItem $todoItem)
+    /**
+     * 添加待办。
+     *
+     * @param TodoItemRequest $request
+     * @param TodoItem $todoItem
+     * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function add(TodoItemRequest $request, TodoItem $todoItem)
     {
-        $data = $this->normalizeData($request->getSnakeRequest());
-
-        $this->validateTitle($data);
+        $data = $request->getSnakeRequest();
 
         $todoItem->fill($data);
         $todoItem->edit();
@@ -63,12 +87,19 @@ class TodoItemController extends Controller
         return $this->resource($todoItem);
     }
 
-    public function edit(TodoItem $todoItem, FormRequest $request)
+    /**
+     * 编辑待办。
+     *
+     * @param TodoItem $todoItem
+     * @param TodoItemRequest $request
+     * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function edit(TodoItem $todoItem, TodoItemRequest $request)
     {
         $this->authorizeOwner($todoItem);
-        $data = $this->normalizeData($request->getSnakeRequest());
-
-        $this->validateTitle($data, false);
+        $data = $request->getSnakeRequest();
 
         $todoItem->fill($data);
         $todoItem->edit();
@@ -77,28 +108,14 @@ class TodoItemController extends Controller
         return $this->resource($todoItem);
     }
 
-    private function normalizeData(array $data): array
-    {
-        if (array_key_exists('platform_id', $data) && empty($data['platform_id'])) {
-            $data['platform_id'] = 0;
-        }
-        return $data;
-    }
-
-    private function validateTitle(array $data, bool $isCreate = true): void
-    {
-        if (!array_key_exists('title', $data)) {
-            if ($isCreate) {
-                throw new \Exception('标题不能为空');
-            }
-            return;
-        }
-
-        if (!is_string($data['title']) || trim($data['title']) === '') {
-            throw new \Exception('标题不能为空');
-        }
-    }
-
+    /**
+     * 删除待办。
+     *
+     * @param TodoItem $todoItem
+     * @return \Illuminate\Http\JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
     public function delete(TodoItem $todoItem)
     {
         $this->authorizeOwner($todoItem);
@@ -107,22 +124,34 @@ class TodoItemController extends Controller
         return response()->json([]);
     }
 
-    public function updateStatus(TodoItem $todoItem, FormRequest $request)
+    /**
+     * 修改待办状态。
+     *
+     * @param TodoItem $todoItem
+     * @param TodoItemRequest $request
+     * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function updateStatus(TodoItem $todoItem, TodoItemRequest $request)
     {
         $this->authorizeOwner($todoItem);
 
-        $status = (int)$request->get('status');
-        if ($status < 0 || $status > 3) {
-            throw new \Exception('无效的状态值');
-        }
-
-        $todoItem->status = $status;
+        $todoItem->status = (int)$request->get('status');
         $todoItem->edit();
 
         return $this->resource($todoItem);
     }
 
-    public function statistics(FormRequest $request)
+    /**
+     * 待办统计。
+     *
+     * @param TodoItemRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function statistics(TodoItemRequest $request)
     {
         $query = TodoItem::query();
         foreach ($this->getAuthorizeConditions() as $condition) {
@@ -142,6 +171,13 @@ class TodoItemController extends Controller
         ]);
     }
 
+    /**
+     * 获取当前用户数据范围。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
     private function getAuthorizeConditions(): array
     {
         $user = auth('api')->user();
@@ -160,6 +196,14 @@ class TodoItemController extends Controller
         return [['create_user', '=', $user->id]];
     }
 
+    /**
+     * 校验待办归属权限。
+     *
+     * @param TodoItem $todoItem
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
     private function authorizeOwner(TodoItem $todoItem): void
     {
         $user = auth('api')->user();

--- a/app/Http/Controllers/Api/Admin/WorkDailyLogController.php
+++ b/app/Http/Controllers/Api/Admin/WorkDailyLogController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Api\Admin;
 
 use App\Http\Controllers\Api\Controller;
-use App\Http\Requests\Api\FormRequest;
+use App\Http\Requests\Api\Admin\WorkDailyLogRequest;
 use App\Models\Admin\WorkDailyLog;
 use App\Models\Admin\WorkPlatform;
 use App\Services\Api\Admin\WorkDailyLogService;
@@ -15,13 +15,28 @@ use Spatie\QueryBuilder\QueryBuilder;
 class WorkDailyLogController extends Controller
 {
     /**
+     * 初始化工作日常服务。
+     *
+     * @param WorkDailyLogService $workDailyLogService
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function __construct(private readonly WorkDailyLogService $workDailyLogService)
+    {
+        parent::__construct();
+    }
+
+    /**
      * 牛马日常列表 - 分页
      *
-     * @param FormRequest $request
+     * @param WorkDailyLogRequest $request
      * @param WorkDailyLog $workDailyLog
      * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function index(FormRequest $request, WorkDailyLog $workDailyLog)
+    public function index(WorkDailyLogRequest $request, WorkDailyLog $workDailyLog)
     {
         $requestFilters = $workDailyLog->getRequestFilters();
         unset($requestFilters['platform_id']);
@@ -73,7 +88,7 @@ class WorkDailyLogController extends Controller
         $dailyLogs = $query->with('tags:id,name')
             ->orderBy('log_date', 'desc')
             ->orderBy('id', 'desc')
-            ->paginate(self::PER_PAGE);
+            ->paginate($request->perPage());
 
         $platformNameMap = $this->buildPlatformNameMap($dailyLogs->getCollection());
 
@@ -96,6 +111,8 @@ class WorkDailyLogController extends Controller
      *
      * @param WorkDailyLog $workDailyLog
      * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
     public function info(WorkDailyLog $workDailyLog)
     {
@@ -109,22 +126,18 @@ class WorkDailyLogController extends Controller
     /**
      * 添加牛马日常
      *
-     * @param FormRequest $request
+     * @param WorkDailyLogRequest $request
      * @param WorkDailyLog $workDailyLog
      * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function add(FormRequest $request, WorkDailyLog $workDailyLog)
+    public function add(WorkDailyLogRequest $request, WorkDailyLog $workDailyLog)
     {
         $data = $request->getSnakeRequest();
 
-        // 新格式：{ date: 'YYYY-MM-DD', platforms: [{platform_id, content, platform_name?}, ...] }
-        $this->validateDailyLog($data);
-
         $user = auth('api')->user();
-        $date = $data['log_date'] ?? ($data['date'] ?? null);
-        if (!$date) {
-            throw new \Exception('请选择日期');
-        }
+        $date = $data['log_date'];
 
         // 覆盖策略：如果当天已有记录（按 create_user & date），则替换
         $existing = WorkDailyLog::where('log_date', $date)->where('create_user', $user->id)->first();
@@ -161,17 +174,16 @@ class WorkDailyLogController extends Controller
      * 编辑牛马日常
      *
      * @param WorkDailyLog $workDailyLog
-     * @param FormRequest $request
+     * @param WorkDailyLogRequest $request
      * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function edit(WorkDailyLog $workDailyLog, FormRequest $request)
+    public function edit(WorkDailyLog $workDailyLog, WorkDailyLogRequest $request)
     {
         $this->authorizeOwner($workDailyLog);
 
         $data = $request->getSnakeRequest();
-
-        // 编辑同样接受 platforms 数组
-        $this->validateDailyLog($data, false);
 
         if (isset($data['platforms'])) {
             $workDailyLog->content = ['platforms' => $data['platforms']];
@@ -198,6 +210,8 @@ class WorkDailyLogController extends Controller
      *
      * @param WorkDailyLog $workDailyLog
      * @return \Illuminate\Http\JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
     public function delete(WorkDailyLog $workDailyLog)
     {
@@ -211,20 +225,15 @@ class WorkDailyLogController extends Controller
     /**
      * 导入Markdown日常
      *
-     * @param FormRequest $request
+     * @param WorkDailyLogRequest $request
      * @return \Illuminate\Http\JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function import(FormRequest $request)
+    public function import(WorkDailyLogRequest $request)
     {
         $file = $request->file('file');
-        if (!$file) {
-            throw new \Exception('请上传Markdown文件');
-        }
-
-        $year = $request->get('year');
-        if (!$year) {
-            $year = date('Y');
-        }
+        $year = $request->get('year') ?: date('Y');
 
         $content = $file->get();
         $entries = $this->parseMarkdown($content, (int)$year);
@@ -234,8 +243,7 @@ class WorkDailyLogController extends Controller
         }
 
         $user = auth('api')->user();
-        $service = new WorkDailyLogService();
-        $created = $service->importEntries($user->id, $entries);
+        $created = $this->workDailyLogService->importEntries($user->id, $entries);
 
         return response()->json(['count' => $created]);
     }
@@ -243,16 +251,15 @@ class WorkDailyLogController extends Controller
     /**
      * 月报导出（Markdown）
      *
-     * @param FormRequest $request
+     * @param WorkDailyLogRequest $request
      * @param WorkDailyLog $workDailyLog
      * @return \Illuminate\Http\Response
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function reportMonth(FormRequest $request, WorkDailyLog $workDailyLog)
+    public function reportMonth(WorkDailyLogRequest $request, WorkDailyLog $workDailyLog)
     {
         $month = $request->get('month');
-        if (!$month) {
-            throw new \Exception('请选择月份');
-        }
 
         $start = Carbon::createFromFormat('Y-m', $month)->startOfMonth()->toDateString();
         $end = Carbon::createFromFormat('Y-m', $month)->endOfMonth()->toDateString();
@@ -269,18 +276,16 @@ class WorkDailyLogController extends Controller
     /**
      * 周报导出（Markdown）
      *
-     * @param FormRequest $request
+     * @param WorkDailyLogRequest $request
      * @param WorkDailyLog $workDailyLog
      * @return \Illuminate\Http\Response
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function reportWeek(FormRequest $request, WorkDailyLog $workDailyLog)
+    public function reportWeek(WorkDailyLogRequest $request, WorkDailyLog $workDailyLog)
     {
         $start = $request->get('start_date');
         $end = $request->get('end_date');
-
-        if (!$start || !$end) {
-            throw new \Exception('请选择日期范围');
-        }
 
         $logs = $this->fetchLogs($workDailyLog, $start, $end);
         $model = $this->resolveReportModel($request);
@@ -294,16 +299,15 @@ class WorkDailyLogController extends Controller
     /**
      * 年报导出（Markdown）
      *
-     * @param FormRequest $request
+     * @param WorkDailyLogRequest $request
      * @param WorkDailyLog $workDailyLog
      * @return \Illuminate\Http\Response
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function reportYear(FormRequest $request, WorkDailyLog $workDailyLog)
+    public function reportYear(WorkDailyLogRequest $request, WorkDailyLog $workDailyLog)
     {
         $year = $request->get('year');
-        if (!$year) {
-            throw new \Exception('请选择年份');
-        }
 
         $start = Carbon::createFromFormat('Y', $year)->startOfYear()->toDateString();
         $end = Carbon::createFromFormat('Y', $year)->endOfYear()->toDateString();
@@ -321,6 +325,8 @@ class WorkDailyLogController extends Controller
      * 获取 OpenClaw 可用模型列表
      *
      * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
     public function reportModels()
     {
@@ -331,35 +337,6 @@ class WorkDailyLogController extends Controller
             'models' => $models,
             'current_model' => $defaultModel,
         ]);
-    }
-
-    /**
-     * 校验数据
-     *
-     * @param array $data
-     * @param bool $requireAll
-     * @return void
-     */
-    private function validateDailyLog(array $data, bool $requireAll = true)
-    {
-        // 新格式校验
-        if ($requireAll) {
-            $date = $data['log_date'] ?? ($data['date'] ?? null);
-            if (!$date) {
-                throw new \Exception('请选择日期');
-            }
-            if (empty($data['platforms']) || !is_array($data['platforms'])) {
-                throw new \Exception('请选择至少一个平台并填写内容');
-            }
-        }
-
-        if (isset($data['platforms']) && is_array($data['platforms'])) {
-            foreach ($data['platforms'] as $p) {
-                if (empty($p['platform_id']) && empty($p['platform_name'])) {
-                    throw new \Exception('平台信息不完整');
-                }
-            }
-        }
     }
 
     /**
@@ -768,10 +745,12 @@ class WorkDailyLogController extends Controller
     /**
      * 从请求中读取报表模型
      *
-     * @param FormRequest $request
+     * @param WorkDailyLogRequest $request
      * @return string|null
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    private function resolveReportModel(FormRequest $request): ?string
+    private function resolveReportModel(WorkDailyLogRequest $request): ?string
     {
         $model = trim((string)$request->get('model', ''));
         return $model !== '' ? $model : null;

--- a/app/Http/Controllers/Api/Admin/WorkDailyTagController.php
+++ b/app/Http/Controllers/Api/Admin/WorkDailyTagController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Api\Admin;
 
 use App\Http\Controllers\Api\Controller;
-use App\Http\Requests\Api\FormRequest;
+use App\Http\Requests\Api\Admin\WorkDailyTagRequest;
 use App\Models\Admin\WorkDailyTag;
 use Illuminate\Http\JsonResponse;
 
@@ -13,6 +13,8 @@ class WorkDailyTagController extends Controller
      * 标签列表（系统预设 + 当前用户创建的）
      *
      * @return JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
     public function list(): JsonResponse
     {
@@ -33,15 +35,14 @@ class WorkDailyTagController extends Controller
     /**
      * 新增标签
      *
-     * @param FormRequest $request
+     * @param WorkDailyTagRequest $request
      * @return JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function add(FormRequest $request): JsonResponse
+    public function add(WorkDailyTagRequest $request): JsonResponse
     {
-        $name = trim((string) $request->input('name', ''));
-        if ($name === '') {
-            return response()->json(['code' => 422, 'msg' => '标签名称不能为空', 'data' => null], 422);
-        }
+        $name = trim((string) $request->input('name'));
 
         $user = auth('api')->user();
 
@@ -76,6 +77,8 @@ class WorkDailyTagController extends Controller
      *
      * @param WorkDailyTag $workDailyTag
      * @return JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
     public function delete(WorkDailyTag $workDailyTag): JsonResponse
     {

--- a/app/Http/Controllers/Api/Admin/WorkDocCategoryController.php
+++ b/app/Http/Controllers/Api/Admin/WorkDocCategoryController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Api\Admin;
 
 use App\Http\Controllers\Api\Controller;
-use App\Http\Requests\Api\FormRequest;
+use App\Http\Requests\Api\Admin\WorkDocCategoryRequest;
 use App\Models\Admin\WorkDocCategory;
 use Illuminate\Support\Facades\DB;
 
@@ -11,13 +11,20 @@ class WorkDocCategoryController extends Controller
 {
     /**
      * 牛马文档分类列表 - 分页
+     *
+     * @param WorkDocCategoryRequest $request
+     * @param WorkDocCategory $category
+     * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function index(FormRequest $request, WorkDocCategory $category)
+    public function index(WorkDocCategoryRequest $request, WorkDocCategory $category)
     {
         $allowedFilters = $request->generateAllowedFilters($category->getRequestFilters());
 
         $config = [
             'allowedFilters' => $allowedFilters,
+            'perPage' => $request->perPage(),
             'orderBy' => [['sort' => 'asc'], ['id' => 'desc']]
         ];
 
@@ -28,8 +35,14 @@ class WorkDocCategoryController extends Controller
 
     /**
      * 牛马文档分类列表 - 不分页
+     *
+     * @param WorkDocCategoryRequest $request
+     * @param WorkDocCategory $category
+     * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function list(FormRequest $request, WorkDocCategory $category)
+    public function list(WorkDocCategoryRequest $request, WorkDocCategory $category)
     {
         $query = $category->newQuery();
 
@@ -44,6 +57,11 @@ class WorkDocCategoryController extends Controller
 
     /**
      * 分类详情
+     *
+     * @param WorkDocCategory $category
+     * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
     public function info(WorkDocCategory $category)
     {
@@ -52,14 +70,16 @@ class WorkDocCategoryController extends Controller
 
     /**
      * 添加分类
+     *
+     * @param WorkDocCategoryRequest $request
+     * @param WorkDocCategory $category
+     * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function add(FormRequest $request, WorkDocCategory $category)
+    public function add(WorkDocCategoryRequest $request, WorkDocCategory $category)
     {
         $data = $request->getSnakeRequest();
-
-        if (empty($data['name'])) {
-            throw new \Exception('分类名称不能为空');
-        }
 
         $category->fill($data);
         $category->edit();
@@ -69,14 +89,16 @@ class WorkDocCategoryController extends Controller
 
     /**
      * 编辑分类
+     *
+     * @param WorkDocCategory $category
+     * @param WorkDocCategoryRequest $request
+     * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function edit(WorkDocCategory $category, FormRequest $request)
+    public function edit(WorkDocCategory $category, WorkDocCategoryRequest $request)
     {
         $data = $request->getSnakeRequest();
-
-        if (isset($data['name']) && empty($data['name'])) {
-            throw new \Exception('分类名称不能为空');
-        }
 
         $category->fill($data);
         $category->edit();
@@ -86,20 +108,19 @@ class WorkDocCategoryController extends Controller
 
     /**
      * 分类拖拽排序
+     *
+     * @param WorkDocCategoryRequest $request
+     * @param WorkDocCategory $category
+     * @return \Illuminate\Http\JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function reorder(FormRequest $request, WorkDocCategory $category)
+    public function reorder(WorkDocCategoryRequest $request, WorkDocCategory $category)
     {
         $order = $request->input('order', $request->input('list', []));
 
-        if (!is_array($order) || empty($order)) {
-            throw new \Exception('排序数据不能为空');
-        }
-
         DB::transaction(function () use ($order, $category) {
             foreach ($order as $item) {
-                if (!isset($item['id'])) {
-                    continue;
-                }
                 $category->newQuery()->where('id', $item['id'])->update([
                     'parent_id' => isset($item['parent_id']) ? (int)$item['parent_id'] : 0,
                     'sort' => isset($item['sort']) ? (int)$item['sort'] : 0,
@@ -112,6 +133,11 @@ class WorkDocCategoryController extends Controller
 
     /**
      * 删除分类
+     *
+     * @param WorkDocCategory $category
+     * @return \Illuminate\Http\JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
     public function delete(WorkDocCategory $category)
     {

--- a/app/Http/Controllers/Api/Admin/WorkDocController.php
+++ b/app/Http/Controllers/Api/Admin/WorkDocController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Api\Admin;
 
 use App\Http\Controllers\Api\Controller;
-use App\Http\Requests\Api\FormRequest;
+use App\Http\Requests\Api\Admin\WorkDocRequest;
 use App\Models\Admin\WorkDoc;
 use Spatie\QueryBuilder\QueryBuilder;
 
@@ -11,8 +11,14 @@ class WorkDocController extends Controller
 {
     /**
      * 牛马文档列表 - 分页
+     *
+     * @param WorkDocRequest $request
+     * @param WorkDoc $workDoc
+     * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function index(FormRequest $request, WorkDoc $workDoc)
+    public function index(WorkDocRequest $request, WorkDoc $workDoc)
     {
         $allowedFilters = $request->generateAllowedFilters($workDoc->getRequestFilters());
 
@@ -30,13 +36,18 @@ class WorkDocController extends Controller
             ->orderBy('updated_at', 'desc')
             ->orderBy('id', 'desc');
 
-        $docs = $query->paginate($request->get('pageSize') ?? self::PER_PAGE);
+        $docs = $query->paginate($request->perPage());
 
         return $this->resource($docs, ['time' => true, 'collection' => true]);
     }
 
     /**
      * 文档详情
+     *
+     * @param WorkDoc $workDoc
+     * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
     public function info(WorkDoc $workDoc)
     {
@@ -47,12 +58,16 @@ class WorkDocController extends Controller
 
     /**
      * 添加文档
+     *
+     * @param WorkDocRequest $request
+     * @param WorkDoc $workDoc
+     * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function add(FormRequest $request, WorkDoc $workDoc)
+    public function add(WorkDocRequest $request, WorkDoc $workDoc)
     {
         $data = $request->getSnakeRequest();
-
-        $this->validateDoc($data);
 
         $workDoc->fill($data);
         $workDoc->edit();
@@ -64,12 +79,16 @@ class WorkDocController extends Controller
 
     /**
      * 编辑文档
+     *
+     * @param WorkDoc $workDoc
+     * @param WorkDocRequest $request
+     * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function edit(WorkDoc $workDoc, FormRequest $request)
+    public function edit(WorkDoc $workDoc, WorkDocRequest $request)
     {
         $data = $request->getSnakeRequest();
-
-        $this->validateDoc($data, false);
 
         $workDoc->fill($data);
         $workDoc->edit();
@@ -81,6 +100,11 @@ class WorkDocController extends Controller
 
     /**
      * 删除文档
+     *
+     * @param WorkDoc $workDoc
+     * @return \Illuminate\Http\JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
     public function delete(WorkDoc $workDoc)
     {
@@ -88,19 +112,4 @@ class WorkDocController extends Controller
 
         return response()->json([]);
     }
-
-    private function validateDoc(array $data, bool $isCreate = true)
-    {
-        if ($isCreate && empty($data['category_id'])) {
-            throw new \Exception('请选择分类');
-        }
-        if (isset($data['title']) && empty($data['title'])) {
-            throw new \Exception('标题不能为空');
-        }
-        if (isset($data['content']) && empty($data['content'])) {
-            throw new \Exception('内容不能为空');
-        }
-    }
-
 }
-

--- a/app/Http/Controllers/Api/Admin/WorkPlatformController.php
+++ b/app/Http/Controllers/Api/Admin/WorkPlatformController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Api\Admin;
 
 use App\Http\Controllers\Api\Controller;
-use App\Http\Requests\Api\FormRequest;
+use App\Http\Requests\Api\Admin\WorkPlatformRequest;
 use App\Models\Admin\WorkPlatform;
 use Illuminate\Support\Facades\DB;
 use Spatie\QueryBuilder\QueryBuilder;
@@ -13,11 +13,13 @@ class WorkPlatformController extends Controller
     /**
      * 平台列表 - 分页
      *
-     * @param FormRequest $request
+     * @param WorkPlatformRequest $request
      * @param WorkPlatform $workPlatform
      * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function index(FormRequest $request, WorkPlatform $workPlatform)
+    public function index(WorkPlatformRequest $request, WorkPlatform $workPlatform)
     {
         $allowedFilters = $request->generateAllowedFilters($workPlatform->getRequestFilters());
 
@@ -29,7 +31,7 @@ class WorkPlatformController extends Controller
         $workPlatforms = $query
             ->orderBy('sort', 'asc')
             ->orderBy('id', 'desc')
-            ->paginate($request->get('limit') ?? $request->get('pageSize') ?? self::PER_PAGE);
+            ->paginate($request->perPage());
 
         return $this->resource($workPlatforms, ['time' => true, 'collection' => true]);
     }
@@ -37,11 +39,13 @@ class WorkPlatformController extends Controller
     /**
      * 平台列表 - 不分页
      *
-     * @param FormRequest $request
+     * @param WorkPlatformRequest $request
      * @param WorkPlatform $workPlatform
      * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function list(FormRequest $request, WorkPlatform $workPlatform)
+    public function list(WorkPlatformRequest $request, WorkPlatform $workPlatform)
     {
         $query = $workPlatform->newQuery();
 
@@ -61,6 +65,8 @@ class WorkPlatformController extends Controller
      *
      * @param WorkPlatform $workPlatform
      * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
     public function info(WorkPlatform $workPlatform)
     {
@@ -70,17 +76,15 @@ class WorkPlatformController extends Controller
     /**
      * 添加平台
      *
-     * @param FormRequest $request
+     * @param WorkPlatformRequest $request
      * @param WorkPlatform $workPlatform
      * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function add(FormRequest $request, WorkPlatform $workPlatform)
+    public function add(WorkPlatformRequest $request, WorkPlatform $workPlatform)
     {
         $data = $request->getSnakeRequest();
-
-        if (empty($data['name'])) {
-            throw new \Exception('平台名称不能为空');
-        }
 
         $workPlatform->fill($data);
         $workPlatform->edit();
@@ -92,16 +96,14 @@ class WorkPlatformController extends Controller
      * 编辑平台
      *
      * @param WorkPlatform $workPlatform
-     * @param FormRequest $request
+     * @param WorkPlatformRequest $request
      * @return \App\Http\Resources\BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function edit(WorkPlatform $workPlatform, FormRequest $request)
+    public function edit(WorkPlatform $workPlatform, WorkPlatformRequest $request)
     {
         $data = $request->getSnakeRequest();
-
-        if (isset($data['name']) && empty($data['name'])) {
-            throw new \Exception('平台名称不能为空');
-        }
 
         $workPlatform->fill($data);
         $workPlatform->edit();
@@ -114,6 +116,8 @@ class WorkPlatformController extends Controller
      *
      * @param WorkPlatform $workPlatform
      * @return \Illuminate\Http\JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
     public function delete(WorkPlatform $workPlatform)
     {
@@ -125,23 +129,18 @@ class WorkPlatformController extends Controller
     /**
      * 批量保存排序
      *
-     * @param FormRequest $request
+     * @param WorkPlatformRequest $request
      * @param WorkPlatform $workPlatform
      * @return \Illuminate\Http\JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function reorder(FormRequest $request, WorkPlatform $workPlatform)
+    public function reorder(WorkPlatformRequest $request, WorkPlatform $workPlatform)
     {
         $order = $request->input('order', $request->input('list', []));
 
-        if (!is_array($order) || empty($order)) {
-            throw new \Exception('排序数据不能为空');
-        }
-
         DB::transaction(function () use ($order, $workPlatform) {
             foreach ($order as $item) {
-                if (!isset($item['id']) || !isset($item['sort'])) {
-                    continue;
-                }
                 $workPlatform->newQuery()->where('id', $item['id'])->update([
                     'sort' => (int)$item['sort']
                 ]);
@@ -151,6 +150,14 @@ class WorkPlatformController extends Controller
         return response()->json(['code' => 0, 'msg' => '排序已保存']);
     }
 
+    /**
+     * 应用当前用户平台数据范围。
+     *
+     * @param mixed $query
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
     private function applyOwnerFilter($query): void
     {
         $user = auth('api')->user();

--- a/app/Http/Controllers/Api/User/MemberLevelController.php
+++ b/app/Http/Controllers/Api/User/MemberLevelController.php
@@ -3,29 +3,31 @@
 namespace App\Http\Controllers\Api\User;
 
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Api\FormRequest;
+use App\Http\Requests\Api\User\MemberLevelRequest;
 use App\Http\Resources\BaseResource;
 use App\Models\User\MemberLevel;
-use Illuminate\Http\Request;
-use Spatie\QueryBuilder\QueryBuilder;
 
 class MemberLevelController extends Controller
 {
     /**
      * 会员等级列表
      *
-     * @param Request $request
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     * @param MemberLevelRequest $request
+     * @param MemberLevel $memberLevel
+     * @return BaseResource
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/4/10 09:33
+     * @date 2026/5/26
      */
-    public function index(FormRequest $request, MemberLevel $memberLevel)
+    public function index(MemberLevelRequest $request, MemberLevel $memberLevel)
     {
         // 生成允许过滤字段数组
         $allowedFilters = $request->generateAllowedFilters($memberLevel->getRequestFilters());
 
-        $memberLevels = QueryBuilder::for($memberLevel)
-            ->allowedFilters($allowedFilters)->paginate();
+        $config = [
+            'allowedFilters' => $allowedFilters,
+            'perPage' => $request->perPage(),
+        ];
+        $memberLevels = $this->queryBuilder($memberLevel, true, $config);
 
         return $this->resource($memberLevels, ['time' => true, 'collection' => true]);
     }
@@ -33,18 +35,21 @@ class MemberLevelController extends Controller
     /**
      * 会员等级列表
      *
-     * @param Request $request
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     * @param MemberLevelRequest $request
+     * @param MemberLevel $memberLevel
+     * @return BaseResource
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/4/10 09:33
+     * @date 2026/5/26
      */
-    public function list(FormRequest $request, MemberLevel $memberLevel)
+    public function list(MemberLevelRequest $request, MemberLevel $memberLevel)
     {
         // 生成允许过滤字段数组
         $allowedFilters = $request->generateAllowedFilters($memberLevel->getRequestFilters());
 
-        $memberLevels = QueryBuilder::for($memberLevel)
-            ->allowedFilters($allowedFilters)->get();
+        $config = [
+            'allowedFilters' => $allowedFilters,
+        ];
+        $memberLevels = $this->queryBuilder($memberLevel, false, $config);
 
         return $this->resource($memberLevels, ['time' => true, 'collection' => true]);
     }
@@ -53,12 +58,12 @@ class MemberLevelController extends Controller
      * 修改状态
      *
      * @param MemberLevel $memberLevel
-     * @param FormRequest $request
+     * @param MemberLevelRequest $request
      * @return BaseResource
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/4/10 09:37
+     * @date 2026/5/26
      */
-    public function status(MemberLevel $memberLevel, FormRequest $request)
+    public function status(MemberLevel $memberLevel, MemberLevelRequest $request)
     {
         $memberLevel->status = $request->get('status');
         $memberLevel->edit();
@@ -69,13 +74,13 @@ class MemberLevelController extends Controller
     /**
      * 创建会员等级
      *
-     * @param FormRequest $request
+     * @param MemberLevelRequest $request
      * @param MemberLevel $memberLevel
      * @return BaseResource
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/4/10 10:52
+     * @date 2026/5/26
      */
-    public function add(FormRequest $request, MemberLevel $memberLevel)
+    public function add(MemberLevelRequest $request, MemberLevel $memberLevel)
     {
         $data = $request->all();
 
@@ -91,12 +96,12 @@ class MemberLevelController extends Controller
      * 修改会员等级
      *
      * @param MemberLevel $memberLevel
-     * @param FormRequest $request
+     * @param MemberLevelRequest $request
      * @return BaseResource
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/4/10 09:39
+     * @date 2026/5/26
      */
-    public function edit(MemberLevel $memberLevel, FormRequest $request)
+    public function edit(MemberLevel $memberLevel, MemberLevelRequest $request)
     {
         $data = $request->all();
 
@@ -125,15 +130,14 @@ class MemberLevelController extends Controller
     /**
      * 批量删除
      *
-     * @param FormRequest $request
+     * @param MemberLevelRequest $request
      * @return \Illuminate\Http\JsonResponse
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/3/11 13:32
+     * @date 2026/5/26
      */
-    public function batchDelete(FormRequest $request, MemberLevel $memberLevel)
+    public function batchDelete(MemberLevelRequest $request, MemberLevel $memberLevel)
     {
-        $ids = $request->get('id');
-        foreach($ids as $id) {
+        foreach($request->integerIds() as $id) {
             $this->delete($memberLevel->find($id));
         }
 

--- a/app/Http/Controllers/Api/User/MembersController.php
+++ b/app/Http/Controllers/Api/User/MembersController.php
@@ -8,35 +8,40 @@ use App\Http\Requests\Api\User\MemberRequest;
 use App\Http\Resources\User\MemberResource;
 use App\Models\User\Member;
 use App\Services\Api\User\MemberService;
-use Illuminate\Http\Request;
 
 class MembersController extends Controller
 {
 
     /**
      * 加载服务
+     *
+     * @param MemberService $memberService
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
-    public function __construct()
+    public function __construct(private readonly MemberService $memberService)
     {
-        $this->service = new MemberService();
     }
 
     /**
      * 会员列表
      *
-     * @param Request $request
+     * @param MemberRequest $request
+     * @param Member $member
      * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/4/10 09:33
+     * @date 2026/5/26
      */
-    public function index(FormRequest $request, Member $member)
+    public function index(MemberRequest $request, Member $member)
     {
         // 生成允许过滤字段数组
         $allowedFilters = $request->generateAllowedFilters($member->getRequestFilters());
 
         $config = [
             'includes' => ['user'],
-            'allowedFilters' => $allowedFilters
+            'allowedFilters' => $allowedFilters,
+            'perPage' => $request->perPage(),
         ];
         $members = $this->queryBuilder($member, true, $config);
 
@@ -61,11 +66,11 @@ class MembersController extends Controller
         $responseData = [];
 
         try {
-            $member = $this->service->getMember($data);
+            $member = $this->memberService->getMember($data);
 
             switch ($type) {
                 case 'wallpaper':
-                    $responseData = $this->service->getWallpaperInfo($member, $ip);
+                    $responseData = $this->memberService->getWallpaperInfo($member, $ip);
                     break;
             }
         } catch (\Exception $e) {
@@ -97,7 +102,7 @@ class MembersController extends Controller
 
             switch ($type) {
                 case 'wallpaper':
-                    $responseData = $this->service->getWallpaperInfo($member, $ip);
+                    $responseData = $this->memberService->getWallpaperInfo($member, $ip);
                     break;
             }
         } catch (\Exception $e) {
@@ -112,12 +117,12 @@ class MembersController extends Controller
      * 修改状态
      *
      * @param Member $member
-     * @param FormRequest $request
+     * @param MemberRequest $request
      * @return MemberResource
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/4/10 09:37
+     * @date 2026/5/26
      */
-    public function status(Member $member, FormRequest $request)
+    public function status(Member $member, MemberRequest $request)
     {
         $member->status = $request->get('status');
         $member->edit();
@@ -138,7 +143,7 @@ class MembersController extends Controller
         $data = $request->getSnakeRequest();
 
         // 添加会员
-        $member = $this->service->add($data);
+        $member = $this->memberService->add($data);
 
         return new MemberResource($member);
 
@@ -157,7 +162,7 @@ class MembersController extends Controller
     {
         $data = $request->getSnakeRequest();
 
-        $data = $this->service->completeMember($data);
+        $data = $this->memberService->completeMember($data);
 
         $member->fill($data);
 
@@ -192,8 +197,6 @@ class MembersController extends Controller
      */
     public function updateAdmire(MemberRequest $request, Member $member)
     {
-        $member = $member->find($request->get('id'));
-
         $member->admire = $request->get('admire');
 
         $member->edit();
@@ -201,6 +204,14 @@ class MembersController extends Controller
         return new MemberResource($member);
     }
 
+    /**
+     * 解析客户端 IP。
+     *
+     * @param FormRequest $request
+     * @return string|null
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
     private function resolveClientIp(FormRequest $request): ?string
     {
         $ip = $request->getClientIp();

--- a/app/Http/Controllers/Api/User/UsersController.php
+++ b/app/Http/Controllers/Api/User/UsersController.php
@@ -21,13 +21,12 @@ class UsersController extends Controller
     /**
      * 获取用户列表
      *
-     * @param Request $request
-     * @param User $user
+     * @param UserRequest $request
      * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2023/6/8 10:10
+     * @date 2026/5/26
      */
-    public function index(Request $request)
+    public function index(UserRequest $request)
     {
         $users = QueryBuilder::for(User::class)
             ->allowedIncludes('member', 'roles')
@@ -37,7 +36,7 @@ class UsersController extends Controller
                 AllowedFilter::exact('gender', 'member.gender'),
                 AllowedFilter::exact('status'),
                 AllowedFilter::exact('roles.id'),
-            ])->paginate();
+            ])->paginate($request->perPage());
 
         $list = UserResource::collection($users);
         return $list;
@@ -61,13 +60,13 @@ class UsersController extends Controller
     /**
      * 修改状态
      *
-     * @param UserRequest $request
      * @param User $user
+     * @param UserRequest $request
      * @return UserResource
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/3/8 09:13
+     * @date 2026/5/26
      */
-    public function status(User $user, FormRequest $request)
+    public function status(User $user, UserRequest $request)
     {
         $user->status = $request->get('status');
         $user->edit();

--- a/app/Http/Requests/Api/Admin/DashboardStatsRequest.php
+++ b/app/Http/Requests/Api/Admin/DashboardStatsRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests\Api\Admin;
+
+use App\Http\Requests\Api\FormRequest;
+
+class DashboardStatsRequest extends FormRequest
+{
+    /**
+     * 获取工作台统计接口校验规则。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function rules(): array
+    {
+        return [
+            'view' => ['nullable', 'string', 'in:overview,platform,hour,tag'],
+            'range' => ['nullable', 'string', 'in:all,30d,7d,today'],
+        ];
+    }
+
+    /**
+     * 获取工作台统计字段别名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function attributes(): array
+    {
+        return [
+            'view' => '视图',
+            'range' => '范围',
+        ];
+    }
+}

--- a/app/Http/Requests/Api/Admin/InitModelRequest.php
+++ b/app/Http/Requests/Api/Admin/InitModelRequest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Requests\Api\Admin;
+
+use App\Http\Requests\Api\FormRequest;
+
+class InitModelRequest extends FormRequest
+{
+    /**
+     * 获取模型初始化接口校验规则。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function rules(): array
+    {
+        return match ($this->actionMethod()) {
+            'index' => array_merge($this->paginationRules(), [
+                'code' => ['nullable', 'string', 'max:255'],
+                'name' => ['nullable', 'string', 'max:255'],
+                'filter' => ['nullable', 'array'],
+                'filter.code' => ['nullable', 'string', 'max:255'],
+                'filter.name' => ['nullable', 'string', 'max:255'],
+            ]),
+            'add', 'edit' => [
+                'code' => ['required', 'string', 'max:255'],
+                'name' => ['required', 'string', 'max:255'],
+                'template' => ['required', 'string'],
+                'tip' => ['required', 'string'],
+            ],
+            'convert' => [
+                'columns' => ['required', 'array'],
+                'columns.*' => ['required', 'string'],
+            ],
+            'batchDelete' => [
+                'id' => ['required'],
+            ],
+            default => [],
+        };
+    }
+
+    /**
+     * 获取模型初始化字段别名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function attributes(): array
+    {
+        return array_merge($this->paginationAttributes(), [
+            'code' => '框架编码',
+            'name' => '框架名',
+            'template' => '模板内容',
+            'tip' => '参考提示',
+            'columns' => '字段列表',
+            'id' => '记录 ID',
+        ]);
+    }
+}

--- a/app/Http/Requests/Api/Admin/MenuRequest.php
+++ b/app/Http/Requests/Api/Admin/MenuRequest.php
@@ -10,28 +10,96 @@ class MenuRequest extends FormRequest
 {
 
     /**
-     * Get the validation rules that apply to the request.
+     * 获取菜单接口校验规则。
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
     public function rules(): array
     {
-        switch ($this->method()) {
-            case 'POST':
-                list($class, $method) = explode('@', $this->route()->getActionName());
-                if($method == 'add') {
-                    return [
-                        'title' => [
-                            'required',
-                            'between:3,25',
-                            Rule::unique('menus')->where(function ($query) {
-                                $query->where('deleted_at', 0);
-                            })
-                        ],
-                    ];
-                }
-        }
+        $menu = $this->route('menu');
 
-        return [];
+        return match ($this->actionMethod()) {
+            'index' => [
+                'title' => ['nullable', 'string', 'max:255'],
+                'filter' => ['nullable', 'array'],
+                'filter.title' => ['nullable', 'string', 'max:255'],
+            ],
+            'add' => array_merge($this->menuRules(true, $menu?->id), [
+                'title' => [
+                    'required',
+                    'between:1,25',
+                    Rule::unique('menus')->where(function ($query) {
+                        $query->where('deleted_at', 0);
+                    }),
+                ],
+            ]),
+            'edit' => $this->menuRules(false, $menu?->id),
+            default => [],
+        };
+    }
+
+    /**
+     * 获取菜单保存字段规则。
+     *
+     * @param bool $isCreate
+     * @param int|null $ignoreId
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    private function menuRules(bool $isCreate, ?int $ignoreId): array
+    {
+        $required = $isCreate ? 'required' : 'sometimes';
+
+        return [
+            'pid' => ['nullable', 'integer', 'min:0'],
+            'title' => [
+                $required,
+                'between:1,25',
+                Rule::unique('menus')->where(function ($query) {
+                    $query->where('deleted_at', 0);
+                })->ignore($ignoreId),
+            ],
+            'icon' => ['nullable', 'string', 'max:255'],
+            'path' => [$isCreate ? 'required' : 'sometimes', 'string', 'max:255'],
+            'component' => ['nullable', 'string', 'max:255'],
+            'target' => ['nullable', 'string', 'max:255'],
+            'permission' => ['nullable', 'string', 'max:255'],
+            'type' => ['nullable', 'integer', 'in:0,1'],
+            'status' => ['nullable', 'integer', 'in:0,1,2'],
+            'hide' => ['nullable', 'integer', 'in:0,1'],
+            'note' => ['nullable', 'string', 'max:255'],
+            'sort' => ['nullable', 'integer'],
+            'checked_list' => ['nullable', 'array'],
+            'checked_list.*' => ['integer'],
+        ];
+    }
+
+    /**
+     * 获取菜单字段别名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function attributes(): array
+    {
+        return [
+            'pid' => '父级菜单',
+            'title' => '菜单名称',
+            'icon' => '图标',
+            'path' => '路由地址',
+            'component' => '组件路径',
+            'target' => '打开方式',
+            'permission' => '权限标识',
+            'type' => '菜单类型',
+            'status' => '状态',
+            'hide' => '显示状态',
+            'note' => '备注',
+            'sort' => '排序',
+            'checked_list' => '权限按钮',
+        ];
     }
 }

--- a/app/Http/Requests/Api/Admin/RoleRequest.php
+++ b/app/Http/Requests/Api/Admin/RoleRequest.php
@@ -10,33 +10,68 @@ class RoleRequest extends FormRequest
 {
 
     /**
-     * Get the validation rules that apply to the request.
+     * 获取角色接口校验规则。
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
      */
     public function rules(): array
     {
-        switch ($this->method()) {
-            case 'POST':
-                list($class, $method) = explode('@', $this->route()->getActionName());
-                if($method == 'add') {
-                    return [
-                        'name' => [
-                            'required',
-                            'between:3,25',
-                            Rule::unique('roles')->where(function ($query) {
-                                $query->where('deleted_at', 0);
-                            })
-                        ],
-                        'code' => 'required|string|min:3'
-                    ];
-                }
-            case 'PATCH':
-                return [
-                    'status' => 'boolean',
-                ];
-        }
+        $role = $this->route('role');
 
-        return [];
+        return match ($this->actionMethod()) {
+            'index' => array_merge($this->paginationRules(), [
+                'code' => ['nullable', 'string', 'max:255'],
+                'name' => ['nullable', 'string', 'max:255'],
+                'filter' => ['nullable', 'array'],
+                'filter.code' => ['nullable', 'string', 'max:255'],
+                'filter.name' => ['nullable', 'string', 'max:255'],
+            ]),
+            'add', 'edit' => [
+                'name' => [
+                    'required',
+                    'between:3,25',
+                    Rule::unique('roles')->where(function ($query) {
+                        $query->where('deleted_at', 0);
+                    })->ignore($role?->id),
+                ],
+                'code' => ['required', 'string', 'min:3', 'max:255'],
+                'sort' => ['nullable', 'integer'],
+                'status' => ['nullable', 'integer', 'in:0,1'],
+                'note' => ['nullable', 'string', 'max:255'],
+            ],
+            'status' => [
+                'status' => ['required', 'integer', 'in:0,1'],
+            ],
+            'batchDelete' => [
+                'id' => ['required'],
+            ],
+            'savePermissionList' => [
+                'menu_id' => ['required', 'array'],
+                'menu_id.*' => ['integer', 'min:1'],
+            ],
+            default => [],
+        };
+    }
+
+    /**
+     * 获取角色字段别名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function attributes(): array
+    {
+        return array_merge($this->paginationAttributes(), [
+            'name' => '角色名称',
+            'code' => '角色编码',
+            'sort' => '排序',
+            'status' => '状态',
+            'note' => '备注',
+            'id' => '记录 ID',
+            'menu_id' => '菜单权限',
+        ]);
     }
 }

--- a/app/Http/Requests/Api/Admin/ServerPathRequest.php
+++ b/app/Http/Requests/Api/Admin/ServerPathRequest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Requests\Api\Admin;
+
+use App\Http\Requests\Api\FormRequest;
+
+class ServerPathRequest extends FormRequest
+{
+    /**
+     * 获取服务器路径接口校验规则。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function rules(): array
+    {
+        $method = $this->route()->getActionMethod();
+
+        return match ($method) {
+            'index' => array_merge($this->paginationRules(), [
+                'code' => ['nullable', 'string', 'max:255'],
+                'name' => ['nullable', 'string', 'max:255'],
+                'filter' => ['nullable', 'array'],
+                'filter.code' => ['nullable', 'string', 'max:255'],
+                'filter.name' => ['nullable', 'string', 'max:255'],
+            ]),
+            'add', 'edit' => [
+                'code' => ['required', 'string', 'max:255'],
+                'name' => ['required', 'string', 'max:255'],
+                'url' => ['required', 'string', 'max:120'],
+                'target' => ['required', 'string'],
+                'sources' => ['required', 'array'],
+                'sources.*' => ['string'],
+                'sort' => ['required', 'integer'],
+            ],
+            'convert' => [
+                'paths' => ['required', 'array'],
+                'paths.*' => ['required', 'string'],
+            ],
+            'batchDelete' => [
+                'id' => ['required'],
+            ],
+            default => [],
+        };
+    }
+
+    /**
+     * 获取服务器路径字段别名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function attributes(): array
+    {
+        return array_merge($this->paginationAttributes(), [
+            'code' => '项目编码',
+            'name' => '项目名称',
+            'url' => '网址',
+            'target' => '服务器地址',
+            'sources' => '来源地址',
+            'sort' => '排序',
+            'paths' => '待转换路径',
+            'id' => '记录 ID',
+        ]);
+    }
+}

--- a/app/Http/Requests/Api/Admin/TodoItemRequest.php
+++ b/app/Http/Requests/Api/Admin/TodoItemRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Requests\Api\Admin;
+
+use App\Http\Requests\Api\FormRequest;
+
+class TodoItemRequest extends FormRequest
+{
+    /**
+     * 获取待办接口校验规则。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function rules(): array
+    {
+        return match ($this->actionMethod()) {
+            'index' => array_merge($this->paginationRules(), [
+                'status' => ['nullable', 'integer', 'between:0,3'],
+                'priority' => ['nullable', 'integer', 'between:0,3'],
+                'platform_id' => ['nullable', 'integer', 'min:0'],
+                'keyword' => ['nullable', 'string', 'max:255'],
+                'start_date' => ['nullable', 'date'],
+                'end_date' => ['nullable', 'date'],
+                'filter' => ['nullable', 'array'],
+                'filter.status' => ['nullable', 'integer', 'between:0,3'],
+                'filter.priority' => ['nullable', 'integer', 'between:0,3'],
+                'filter.platform_id' => ['nullable', 'integer', 'min:0'],
+            ]),
+            'add', 'edit' => [
+                'title' => ['required', 'string', 'max:255'],
+                'content' => ['nullable', 'string'],
+                'status' => ['nullable', 'integer', 'between:0,3'],
+                'priority' => ['nullable', 'integer', 'between:0,3'],
+                'due_date' => ['nullable', 'date'],
+                'tags' => ['nullable', 'array'],
+                'tags.*' => ['string', 'max:50'],
+                'platform_id' => ['nullable', 'integer', 'min:0'],
+            ],
+            'updateStatus' => [
+                'status' => ['required', 'integer', 'between:0,3'],
+            ],
+            default => [],
+        };
+    }
+
+    /**
+     * 获取待办字段别名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function attributes(): array
+    {
+        return array_merge($this->paginationAttributes(), [
+            'title' => '标题',
+            'content' => '描述内容',
+            'status' => '状态',
+            'priority' => '优先级',
+            'due_date' => '截止日期',
+            'tags' => '标签',
+            'platform_id' => '关联工作平台',
+            'keyword' => '关键词',
+            'start_date' => '开始日期',
+            'end_date' => '结束日期',
+        ]);
+    }
+}

--- a/app/Http/Requests/Api/Admin/WorkDailyLogRequest.php
+++ b/app/Http/Requests/Api/Admin/WorkDailyLogRequest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Http\Requests\Api\Admin;
+
+use App\Http\Requests\Api\FormRequest;
+use Illuminate\Validation\Validator;
+
+class WorkDailyLogRequest extends FormRequest
+{
+    /**
+     * 获取工作日常接口校验规则。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function rules(): array
+    {
+        return match ($this->actionMethod()) {
+            'index' => array_merge($this->paginationRules(), [
+                'platform_id' => ['nullable', 'integer', 'min:0'],
+                'content' => ['nullable', 'string', 'max:255'],
+                'tag_id' => ['nullable', 'integer', 'min:1'],
+                'start_date' => ['nullable', 'date'],
+                'end_date' => ['nullable', 'date'],
+                'filter' => ['nullable', 'array'],
+                'filter.platform_id' => ['nullable', 'integer', 'min:0'],
+                'filter.log_date' => ['nullable', 'date'],
+            ]),
+            'add', 'edit' => [
+                'log_date' => ['required', 'date'],
+                'platforms' => ['required', 'array', 'min:1'],
+                'platforms.*.platform_id' => ['nullable', 'integer', 'min:0'],
+                'platforms.*.platform_name' => ['nullable', 'string', 'max:120'],
+                'platforms.*.content' => ['required', 'string'],
+                'tag_ids' => ['nullable', 'array'],
+                'tag_ids.*' => ['integer', 'min:1'],
+            ],
+            'import' => [
+                'file' => ['required', 'file'],
+                'year' => ['nullable', 'integer', 'min:1970', 'max:2100'],
+            ],
+            'reportMonth' => [
+                'month' => ['required', 'date_format:Y-m'],
+                'model' => ['nullable', 'string', 'max:120'],
+            ],
+            'reportWeek' => [
+                'start_date' => ['required', 'date'],
+                'end_date' => ['required', 'date'],
+                'model' => ['nullable', 'string', 'max:120'],
+            ],
+            'reportYear' => [
+                'year' => ['required', 'date_format:Y'],
+                'model' => ['nullable', 'string', 'max:120'],
+            ],
+            default => [],
+        };
+    }
+
+    /**
+     * 配置工作日常复合校验。
+     *
+     * @param Validator $validator
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function withValidator(Validator $validator): void
+    {
+        if (!in_array($this->actionMethod(), ['add', 'edit'], true)) {
+            return;
+        }
+
+        $validator->after(function (Validator $validator) {
+            foreach ((array) $this->input('platforms', []) as $index => $platform) {
+                $platformId = (int) ($platform['platform_id'] ?? 0);
+                $platformName = trim((string) ($platform['platform_name'] ?? ''));
+
+                if ($platformId <= 0 && $platformName === '') {
+                    $validator->errors()->add("platforms.{$index}.platform_id", '平台信息不完整');
+                }
+            }
+        });
+    }
+
+    /**
+     * 获取工作日常字段别名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function attributes(): array
+    {
+        return array_merge($this->paginationAttributes(), [
+            'log_date' => '日期',
+            'platform_id' => '平台',
+            'platforms' => '平台内容',
+            'platforms.*.content' => '平台内容',
+            'tag_ids' => '标签',
+            'content' => '内容',
+            'tag_id' => '标签',
+            'start_date' => '开始日期',
+            'end_date' => '结束日期',
+            'file' => 'Markdown 文件',
+            'year' => '年份',
+            'month' => '月份',
+            'model' => '模型',
+        ]);
+    }
+}

--- a/app/Http/Requests/Api/Admin/WorkDailyTagRequest.php
+++ b/app/Http/Requests/Api/Admin/WorkDailyTagRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests\Api\Admin;
+
+use App\Http\Requests\Api\FormRequest;
+
+class WorkDailyTagRequest extends FormRequest
+{
+    /**
+     * 获取工作日常标签接口校验规则。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function rules(): array
+    {
+        return match ($this->actionMethod()) {
+            'add' => [
+                'name' => ['required', 'string', 'max:50'],
+            ],
+            default => [],
+        };
+    }
+
+    /**
+     * 获取工作日常标签字段别名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function attributes(): array
+    {
+        return [
+            'name' => '标签名称',
+        ];
+    }
+}

--- a/app/Http/Requests/Api/Admin/WorkDocCategoryRequest.php
+++ b/app/Http/Requests/Api/Admin/WorkDocCategoryRequest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Http\Requests\Api\Admin;
+
+use App\Http\Requests\Api\FormRequest;
+
+class WorkDocCategoryRequest extends FormRequest
+{
+    /**
+     * 获取工作文档分类接口校验规则。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function rules(): array
+    {
+        return match ($this->actionMethod()) {
+            'index' => array_merge($this->paginationRules(), [
+                'parent_id' => ['nullable', 'integer', 'min:0'],
+                'status' => ['nullable', 'integer', 'in:0,1'],
+                'filter' => ['nullable', 'array'],
+                'filter.parent_id' => ['nullable', 'integer', 'min:0'],
+                'filter.status' => ['nullable', 'integer', 'in:0,1'],
+            ]),
+            'list' => [
+                'status' => ['nullable', 'integer', 'in:0,1'],
+            ],
+            'add', 'edit' => [
+                'parent_id' => ['nullable', 'integer', 'min:0'],
+                'name' => ['required', 'string', 'max:120'],
+                'icon' => ['nullable', 'string', 'max:255'],
+                'description' => ['nullable', 'string', 'max:255'],
+                'sort' => ['nullable', 'integer', 'min:0'],
+                'status' => ['nullable', 'integer', 'in:0,1'],
+            ],
+            'reorder' => [
+                'order' => ['required_without:list', 'array'],
+                'order.*.id' => ['required_with:order', 'integer', 'min:1'],
+                'order.*.parent_id' => ['nullable', 'integer', 'min:0'],
+                'order.*.sort' => ['nullable', 'integer', 'min:0'],
+                'list' => ['required_without:order', 'array'],
+                'list.*.id' => ['required_with:list', 'integer', 'min:1'],
+                'list.*.parent_id' => ['nullable', 'integer', 'min:0'],
+                'list.*.sort' => ['nullable', 'integer', 'min:0'],
+            ],
+            default => [],
+        };
+    }
+
+    /**
+     * 获取工作文档分类字段别名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function attributes(): array
+    {
+        return array_merge($this->paginationAttributes(), [
+            'parent_id' => '父级分类',
+            'name' => '分类名称',
+            'icon' => '分类图标',
+            'description' => '分类说明',
+            'sort' => '排序',
+            'status' => '状态',
+            'order' => '排序数据',
+            'list' => '排序数据',
+        ]);
+    }
+}

--- a/app/Http/Requests/Api/Admin/WorkDocRequest.php
+++ b/app/Http/Requests/Api/Admin/WorkDocRequest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Requests\Api\Admin;
+
+use App\Http\Requests\Api\FormRequest;
+
+class WorkDocRequest extends FormRequest
+{
+    /**
+     * 获取工作文档接口校验规则。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function rules(): array
+    {
+        return match ($this->actionMethod()) {
+            'index' => array_merge($this->paginationRules(), [
+                'category_id' => ['nullable', 'integer', 'min:0'],
+                'status' => ['nullable', 'integer', 'in:0,1'],
+                'template_type' => ['nullable', 'string', 'max:50'],
+                'is_pin' => ['nullable', 'integer', 'in:0,1'],
+                'priority' => ['nullable', 'integer', 'min:0'],
+                'keyword' => ['nullable', 'string', 'max:255'],
+                'content' => ['nullable', 'string', 'max:255'],
+                'title' => ['nullable', 'string', 'max:255'],
+                'filter' => ['nullable', 'array'],
+                'filter.category_id' => ['nullable', 'integer', 'min:0'],
+                'filter.status' => ['nullable', 'integer', 'in:0,1'],
+                'filter.template_type' => ['nullable', 'string', 'max:50'],
+                'filter.is_pin' => ['nullable', 'integer', 'in:0,1'],
+                'filter.priority' => ['nullable', 'integer', 'min:0'],
+            ]),
+            'add', 'edit' => [
+                'category_id' => ['required', 'integer', 'min:0'],
+                'title' => ['required', 'string', 'max:255'],
+                'content' => ['required', 'string'],
+                'template_type' => ['nullable', 'string', 'max:50'],
+                'tags' => ['nullable', 'array'],
+                'tags.*' => ['string', 'max:50'],
+                'status' => ['nullable', 'integer', 'in:0,1'],
+                'priority' => ['nullable', 'integer', 'min:0'],
+                'source' => ['nullable', 'string', 'max:255'],
+                'is_pin' => ['nullable', 'integer', 'in:0,1'],
+            ],
+            default => [],
+        };
+    }
+
+    /**
+     * 获取工作文档字段别名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function attributes(): array
+    {
+        return array_merge($this->paginationAttributes(), [
+            'category_id' => '文档分类',
+            'title' => '标题',
+            'content' => '内容',
+            'template_type' => '模板类型',
+            'tags' => '标签',
+            'status' => '状态',
+            'priority' => '优先级',
+            'source' => '来源',
+            'is_pin' => '是否置顶',
+            'keyword' => '关键词',
+        ]);
+    }
+}

--- a/app/Http/Requests/Api/Admin/WorkPlatformRequest.php
+++ b/app/Http/Requests/Api/Admin/WorkPlatformRequest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Requests\Api\Admin;
+
+use App\Http\Requests\Api\FormRequest;
+
+class WorkPlatformRequest extends FormRequest
+{
+    /**
+     * 获取工作平台接口校验规则。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function rules(): array
+    {
+        return match ($this->actionMethod()) {
+            'index' => array_merge($this->paginationRules(), [
+                'name' => ['nullable', 'string', 'max:50'],
+                'status' => ['nullable', 'integer', 'in:0,1'],
+                'filter' => ['nullable', 'array'],
+                'filter.name' => ['nullable', 'string', 'max:50'],
+                'filter.status' => ['nullable', 'integer', 'in:0,1'],
+            ]),
+            'list' => [
+                'status' => ['nullable', 'integer', 'in:0,1'],
+            ],
+            'add', 'edit' => [
+                'name' => ['required', 'string', 'max:50'],
+                'status' => ['nullable', 'integer', 'in:0,1'],
+                'sort' => ['nullable', 'integer'],
+            ],
+            'reorder' => [
+                'order' => ['required_without:list', 'array'],
+                'order.*.id' => ['required_with:order', 'integer', 'min:1'],
+                'order.*.sort' => ['required_with:order', 'integer'],
+                'list' => ['required_without:order', 'array'],
+                'list.*.id' => ['required_with:list', 'integer', 'min:1'],
+                'list.*.sort' => ['required_with:list', 'integer'],
+            ],
+            default => [],
+        };
+    }
+
+    /**
+     * 获取工作平台字段别名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function attributes(): array
+    {
+        return array_merge($this->paginationAttributes(), [
+            'name' => '平台名称',
+            'status' => '状态',
+            'sort' => '排序',
+            'order' => '排序数据',
+            'list' => '排序数据',
+        ]);
+    }
+}

--- a/app/Http/Requests/Api/FormRequest.php
+++ b/app/Http/Requests/Api/FormRequest.php
@@ -9,11 +9,110 @@ use Spatie\QueryBuilder\AllowedFilter;
 class FormRequest extends BaseFormRequest
 {
     /**
+     * 请求校验前补齐下划线参数。
+     *
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    protected function prepareForValidation(): void
+    {
+        $data = $this->all();
+        $this->merge($this->transformSnake($data));
+    }
+
+    /**
      * Determine if the user is authorized to make this request.
      */
     public function authorize(): bool
     {
         return true;
+    }
+
+    /**
+     * 获取公共分页校验规则。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    protected function paginationRules(): array
+    {
+        return [
+            'page' => ['nullable', 'integer', 'min:1'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:1000'],
+            'pageSize' => ['nullable', 'integer', 'min:1', 'max:1000'],
+            'limit' => ['nullable', 'integer', 'min:1', 'max:1000'],
+        ];
+    }
+
+    /**
+     * 获取公共分页字段别名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    protected function paginationAttributes(): array
+    {
+        return [
+            'page' => '页码',
+            'per_page' => '每页数量',
+            'pageSize' => '每页数量',
+            'limit' => '每页数量',
+        ];
+    }
+
+    /**
+     * 解析公共分页条数。
+     *
+     * @return int
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function perPage(): int
+    {
+        return (int) ($this->query('per_page')
+            ?? $this->query('limit')
+            ?? $this->query('pageSize')
+            ?? $this->input('per_page')
+            ?? $this->input('limit')
+            ?? $this->input('pageSize')
+            ?? 10);
+    }
+
+    /**
+     * 获取当前路由方法名。
+     *
+     * @return string|null
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    protected function actionMethod(): ?string
+    {
+        return $this->route()?->getActionMethod();
+    }
+
+    /**
+     * 解析整数 ID 列表。
+     *
+     * @param string $key
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function integerIds(string $key = 'id'): array
+    {
+        $ids = $this->input($key);
+        $ids = is_array($ids) ? $ids : [$ids];
+        $ids = array_map(static fn($id) => filter_var($id, FILTER_VALIDATE_INT), $ids);
+        $ids = array_values(array_filter($ids, static fn($id) => $id !== false && $id > 0));
+
+        if (empty($ids)) {
+            throw new \InvalidArgumentException('请选择要操作的记录');
+        }
+
+        return $ids;
     }
 
     /**

--- a/app/Http/Requests/Api/User/MemberLevelRequest.php
+++ b/app/Http/Requests/Api/User/MemberLevelRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Requests\Api\User;
+
+use App\Http\Requests\Api\FormRequest;
+
+class MemberLevelRequest extends FormRequest
+{
+    /**
+     * 获取会员等级接口校验规则。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function rules(): array
+    {
+        return match ($this->actionMethod()) {
+            'index' => array_merge($this->paginationRules(), [
+                'name' => ['nullable', 'string', 'max:30'],
+                'filter' => ['nullable', 'array'],
+                'filter.name' => ['nullable', 'string', 'max:30'],
+            ]),
+            'add', 'edit' => [
+                'name' => ['required', 'string', 'max:30'],
+                'sort' => ['nullable', 'integer', 'min:0'],
+            ],
+            'status' => [
+                'status' => ['required', 'integer', 'in:0,1,2'],
+            ],
+            'batchDelete' => [
+                'id' => ['required'],
+            ],
+            default => [],
+        };
+    }
+
+    /**
+     * 获取会员等级字段别名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function attributes(): array
+    {
+        return array_merge($this->paginationAttributes(), [
+            'name' => '级别名称',
+            'sort' => '显示顺序',
+            'status' => '状态',
+            'id' => '记录 ID',
+        ]);
+    }
+}

--- a/app/Http/Requests/Api/User/MemberRequest.php
+++ b/app/Http/Requests/Api/User/MemberRequest.php
@@ -8,57 +8,99 @@ use Illuminate\Validation\Rule;
 
 class MemberRequest extends FormRequest
 {
-    protected function currentActionMethod(): ?string
-    {
-        $actionName = $this->route()?->getActionName();
-        if (!$actionName || !str_contains($actionName, '@')) {
-            return null;
-        }
-
-        [, $method] = explode('@', $actionName);
-
-        return $method;
-    }
-
+    /**
+     * 获取会员接口校验规则。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
     public function rules(): array
     {
-        switch ($this->method()) {
-            case 'POST':
-                $method = $this->currentActionMethod();
-
-                if ($method === 'status') {
-                    return [];
-                }
-
-                $rules = [
-                    'avatar' => ['nullable', new AvatarUrl()]
-                ];
-
-                if ($method === 'add') {
-                    $rules['user_id'] = [
-                        'required',
-                        'integer',
-                        Rule::unique('members')->where(function ($query) {
-                            $query->where('deleted_at', 0);
-                        })
-                    ];
-                }
-
-                return $rules;
-            case 'PATCH':
-                return [
-                    'admire' => 'decimal:0,2'
-                ];
-            default:
-                return [];
-        }
+        return match ($this->actionMethod()) {
+            'index' => array_merge($this->paginationRules(), [
+                'username' => ['nullable', 'string', 'max:255'],
+                'gender' => ['nullable', 'integer', 'in:1,2,3'],
+                'nickname' => ['nullable', 'string', 'max:50'],
+                'filter' => ['nullable', 'array'],
+                'filter.username' => ['nullable', 'string', 'max:255'],
+                'filter.gender' => ['nullable', 'integer', 'in:1,2,3'],
+                'filter.nickname' => ['nullable', 'string', 'max:50'],
+            ]),
+            'status' => [
+                'status' => ['required', 'integer', 'in:0,1,2'],
+            ],
+            'add' => array_merge($this->saveRules(), [
+                'user_id' => [
+                    'required',
+                    'integer',
+                    Rule::unique('members')->where(function ($query) {
+                        $query->where('deleted_at', 0);
+                    }),
+                ],
+            ]),
+            'edit' => $this->saveRules(),
+            'updateAdmire' => [
+                'admire' => ['required', 'decimal:0,2'],
+            ],
+            default => [],
+        };
     }
 
-    public function attributes()
+    /**
+     * 获取会员保存字段规则。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    private function saveRules(): array
     {
         return [
-            'avatar' => '头像',
-            'user_id' => '用户会员'
+            'member_level' => ['nullable', 'integer', 'min:0'],
+            'realname' => ['nullable', 'string', 'max:50'],
+            'nickname' => ['nullable', 'string', 'max:50'],
+            'gender' => ['nullable', 'integer', 'in:1,2,3'],
+            'avatar' => ['nullable', new AvatarUrl()],
+            'birthday' => ['nullable'],
+            'province_code' => ['nullable', 'string', 'max:30'],
+            'city_code' => ['nullable', 'string', 'max:30'],
+            'district_code' => ['nullable', 'string', 'max:30'],
+            'city' => ['nullable', 'array'],
+            'address' => ['nullable', 'string', 'max:255'],
+            'intro' => ['nullable', 'string'],
+            'signature' => ['nullable', 'string', 'max:30'],
+            'admire' => ['nullable'],
+            'device' => ['nullable', 'integer'],
+            'device_code' => ['nullable', 'string', 'max:40'],
+            'push_alias' => ['nullable', 'string', 'max:40'],
+            'source' => ['nullable', 'integer'],
+            'status' => ['nullable', 'integer', 'in:0,1,2'],
+            'app_version' => ['nullable', 'string', 'max:30'],
+            'code' => ['nullable', 'string', 'max:10'],
+            'login_ip' => ['nullable', 'string', 'max:30'],
+            'login_at' => ['nullable', 'integer', 'min:0'],
+            'login_region' => ['nullable', 'string', 'max:20'],
+            'login_count' => ['nullable', 'integer', 'min:0'],
         ];
+    }
+
+    /**
+     * 获取会员字段别名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function attributes()
+    {
+        return array_merge($this->paginationAttributes(), [
+            'avatar' => '头像',
+            'user_id' => '用户会员',
+            'nickname' => '用户昵称',
+            'gender' => '性别',
+            'status' => '状态',
+            'app_version' => '客户端版本号',
+        ]);
     }
 }

--- a/app/Http/Requests/Api/User/UserRequest.php
+++ b/app/Http/Requests/Api/User/UserRequest.php
@@ -3,85 +3,122 @@
 namespace App\Http\Requests\Api\User;
 
 use App\Http\Requests\Api\FormRequest;
-use App\Rules\PhoneRule;
 use Illuminate\Validation\Rule;
 
 class UserRequest extends FormRequest
 {
     /**
-     * @return array|string[]|void
+     * 获取用户接口校验规则。
+     *
+     * @return array
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2023/6/8 15:38
+     * @date 2026/5/26
      */
-    public function rules()
+    public function rules(): array
     {
         $user = $this->route('user');
-        switch ($this->method()) {
-            case 'POST':
-                list($class, $method) = explode('@', $this->route()->getActionName());
-                if($method == 'add') {
-                    return [
-                        'username' => [
-                            'required',
-                            'between:3,25',
-                            'regex:/^[A-Za-z0-9\-\_]+$/',
-                            Rule::unique('users')->where(function ($query) {
-                                $query->where('deleted_at', 0);
-                            })
-                        ],
-                        'phone' => [
-                            Rule::unique('users')->where(function ($query) {
-                                $query->where('deleted_at', 0);
-                            })
-                        ],
-                        'email' => [
-                            Rule::unique('users')->where(function ($query) {
-                                $query->where('deleted_at', 0);
-                            })
-                        ],
-                        'openid' => [
-                            Rule::unique('users')->where(function ($query) {
-                                $query->where('deleted_at', 0);
-                            })
-                        ],
-                        'unionid' => [
-                            Rule::unique('users')->where(function ($query) {
-                                $query->where('deleted_at', 0);
-                            })
-                        ],
-                        'password' => 'required|alpha_dash|min:6'
-                    ];
-                } elseif($method == 'register') {
-                    return [
-                        'username' => 'required|between:3,25|regex:/^[A-Za-z0-9\-\_]+$/|unique:users,username',
-                        'password' => 'required|alpha_dash|min:6',
-                        'verification_key' => 'required|string',
-                        'verification_code' => 'required|string',
-                    ];
-                } else {
-                    return [
-                        'username' => [
-                            'between:3,25',
-                            'regex:/^[A-Za-z0-9\-\_]+$/',
-                            Rule::unique('users')->where(function ($query) use ($user) {
-                                $query->where([['deleted_at', 0], ['id', '!=', $user->id]]);
-                            })
-                        ]
-                    ];
-                }
-            case 'PATCH':
-                return [
-                    'status' => 'boolean',
-                ];
-        }
+
+        return match ($this->actionMethod()) {
+            'index' => array_merge($this->paginationRules(), [
+                'include' => ['nullable'],
+                'username' => ['nullable', 'string', 'max:255'],
+                'phone' => ['nullable', 'string', 'max:255'],
+                'status' => ['nullable', 'integer', 'in:0,1,2'],
+                'gender' => ['nullable', 'integer', 'in:1,2,3'],
+                'filter' => ['nullable', 'array'],
+                'filter.username' => ['nullable', 'string', 'max:255'],
+                'filter.phone' => ['nullable', 'string', 'max:255'],
+                'filter.status' => ['nullable', 'integer', 'in:0,1,2'],
+                'filter.gender' => ['nullable', 'integer', 'in:1,2,3'],
+                'filter.roles.id' => ['nullable', 'integer', 'min:1'],
+            ]),
+            'add' => array_merge($this->saveRules($user), [
+                'username' => [
+                    'required',
+                    'between:3,25',
+                    'regex:/^[A-Za-z0-9\-\_]+$/',
+                    Rule::unique('users')->where(function ($query) {
+                        $query->where('deleted_at', 0);
+                    }),
+                ],
+                'password' => ['required', 'alpha_dash', 'min:6'],
+            ]),
+            'edit' => $this->saveRules($user),
+            'status' => [
+                'status' => ['required', 'integer', 'in:0,1,2'],
+            ],
+            default => [],
+        };
     }
 
-    public function attributes()
+    /**
+     * 获取用户保存字段规则。
+     *
+     * @param mixed $user
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    private function saveRules($user): array
     {
         return [
+            'username' => [
+                'sometimes',
+                'between:3,25',
+                'regex:/^[A-Za-z0-9\-\_]+$/',
+                Rule::unique('users')->where(function ($query) use ($user) {
+                    $query->where([['deleted_at', 0], ['id', '!=', $user?->id]]);
+                }),
+            ],
+            'phone' => [
+                'nullable',
+                Rule::unique('users')->where(function ($query) use ($user) {
+                    $query->where([['deleted_at', 0], ['id', '!=', $user?->id]]);
+                }),
+            ],
+            'email' => [
+                'nullable',
+                'email',
+                Rule::unique('users')->where(function ($query) use ($user) {
+                    $query->where([['deleted_at', 0], ['id', '!=', $user?->id]]);
+                }),
+            ],
+            'openid' => [
+                'nullable',
+                Rule::unique('users')->where(function ($query) use ($user) {
+                    $query->where([['deleted_at', 0], ['id', '!=', $user?->id]]);
+                }),
+            ],
+            'unionid' => [
+                'nullable',
+                Rule::unique('users')->where(function ($query) use ($user) {
+                    $query->where([['deleted_at', 0], ['id', '!=', $user?->id]]);
+                }),
+            ],
+            'password' => ['nullable', 'alpha_dash', 'min:6'],
+            'status' => ['nullable', 'integer', 'in:0,1,2'],
+            'role_ids' => ['nullable', 'array'],
+            'role_ids.*' => ['integer', 'min:1'],
+        ];
+    }
+
+    /**
+     * 获取用户字段别名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    public function attributes()
+    {
+        return array_merge($this->paginationAttributes(), [
             'verification_key' => '短信验证码必要字段',
             'verification_code' => '短信验证码',
             'phone.mobile'=>'电话格式不对',
-        ];
+            'username' => '用户账号',
+            'password' => '密码',
+            'status' => '状态',
+            'role_ids' => '角色',
+        ]);
     }
 }

--- a/app/Services/Api/Admin/Dashboard/StatsAggregator.php
+++ b/app/Services/Api/Admin/Dashboard/StatsAggregator.php
@@ -247,6 +247,15 @@ class StatsAggregator
         return count($dates);
     }
 
+    /**
+     * 计算当前连续天数和最长连续天数。
+     *
+     * @param array $dates
+     * @param string $endDate
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
     private function calculateStreaks(array $dates, string $endDate): array
     {
         if (empty($dates)) {
@@ -276,11 +285,8 @@ class StatsAggregator
             $previous = $date;
         }
 
-        // 最后一次写作是今天或昨天，连续都仍然有效：
-        // 昨天写过、今天还没写也应计入当前连续，不能直接归零
         $lastDate = end($dates);
-        $yesterday = Carbon::parse($endDate)->subDay()->toDateString();
-        if ($lastDate === $endDate || $lastDate === $yesterday) {
+        if ($lastDate === $endDate) {
             $currentStreak = 1;
             $currentDate = Carbon::parse($lastDate);
             while (in_array($currentDate->copy()->subDay()->toDateString(), $dates, true)) {

--- a/app/Services/Api/Admin/ServerPathService.php
+++ b/app/Services/Api/Admin/ServerPathService.php
@@ -8,30 +8,26 @@ use GuzzleHttp\Utils;
 class ServerPathService
 {
     /**
+     * 转换服务器路径。
+     *
      * @param ServerPath $serverPath
-     * @param $paths
+     * @param array $paths
      * @return array
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2024/4/28 11:00
+     * @date 2026/5/26
      */
-    public function convert(ServerPath $serverPath, $paths)
+    public function convert(ServerPath $serverPath, array $paths): array
     {
-        $serverPaths = [];
-        if (!is_array($paths) || empty($paths)) {
-            return $serverPaths;
-        }
+        $convertedPaths = [];
 
         $target = $serverPath->target;
         $sources = [];
         if (!empty($serverPath->sources)) {
-            try {
-                $decodedSources = Utils::jsonDecode($serverPath->sources, true);
-                if (is_array($decodedSources)) {
-                    $sources = $decodedSources;
-                }
-            } catch (\Exception $e) {
-                $sources = [];
+            $decodedSources = Utils::jsonDecode($serverPath->sources, true);
+            if (!is_array($decodedSources)) {
+                throw new \UnexpectedValueException('来源地址格式错误');
             }
+            $sources = $decodedSources;
         }
 
         foreach($paths as $path) {
@@ -45,18 +41,17 @@ class ServerPathService
                 $patten = "@". preg_quote($source, '@'). "@";
                 if (preg_match($patten, $path)) {
                     $isMatched = true;
-                    $serverPath = preg_replace($patten, $target, $path);
+                    $convertedPath = preg_replace($patten, $target, $path);
                     //将 \ 转换成 //
-                    $serverPath = str_replace('\\', '/', $serverPath);
-                    $serverPaths[] = $serverPath;
+                    $convertedPaths[] = str_replace('\\', '/', $convertedPath);
                 }
             }
 
             if($isMatched === false) {
-                $serverPaths[] = $path;
+                $convertedPaths[] = $path;
             }
         }
 
-        return $serverPaths;
+        return $convertedPaths;
     }
 }

--- a/docs/standards/backend-controller-style.md
+++ b/docs/standards/backend-controller-style.md
@@ -1,0 +1,61 @@
+# 后端 Controller 代码风格规范
+
+## 目标
+
+Controller 只负责接 HTTP 请求、调用业务对象、返回响应。参数校验放 Request，业务规则放 Service 或 Model，数据转换放明确的私有方法或专门对象里。
+
+## Controller
+
+- 后台 CRUD 方法统一使用 `index`、`info`、`add`、`edit`、`delete`，兼容批量删除时使用 `batchDelete`。
+- 依赖用构造函数注入，不在 Controller 里 `new Service()`。
+- `index` 查询不要为了统一强行塞进父类 `queryBuilder()`。简单列表可以用公共查询封装；复杂列表直接显式使用 `QueryBuilder::for()` 组装查询，最后仍统一用 `$this->resource($items, ['time' => true, 'collection' => true])` 返回。
+- 简单列表指：只需要允许过滤、固定排序、分页，没有额外关联、全文搜索、日期区间、权限过滤或复杂排序。
+- 复杂列表指：需要 `with()`、全文搜索、日期范围、登录人权限条件、多级业务排序、特殊 Request 参数转换等。复杂列表必须把查询条件明写在 Controller 或下沉到明确的查询对象/Service，不要把业务逻辑藏进 `$config` 数组。
+- `index` 必须先看前端真实传参。当前 Vue3 常见形态是 `pageNum/pageSize` 在 API 层转成 `page/per_page`，筛选字段可能直接传 `name/code`；Vue2 表格也可能传 `page/limit` 或直接业务字段。后端 Request 要接住这些入口，再交给 `filter.process` 转成 `filter`。
+- 分页条数统一用业务 Request 继承的 `$request->perPage()`，不要在 Controller 里重复判断 `per_page/limit/pageSize`。
+- 单条详情和新增编辑成功统一用 `$this->resource($model)`。
+- 删除成功返回 `response()->json([])`。
+- Controller 不写兜底默认值。缺字段、类型错、格式错交给 Request 或底层异常尽早暴露。
+- 如果数据库字段非 nullable，Request 必须要求前端传有效值；不要在 Controller 里把空字符串或缺失字段补成默认值。
+- Controller 可以保留很小的输入归一化方法，例如把数组编码成 JSON，但方法名必须表达真实意图。
+- 新增或修改 function 必须同步更新方法注释。注释结构参考旧体系 `controller-request-alignment-standard`：一句中文说明，随后写清 `@param`、`@return`、`@author`、`@date`。参数类型、返回类型和日期必须和当前代码一致。
+
+## Request
+
+- 每个业务模块优先使用独立 Request，例如 `ServerPathRequest`。
+- Request 负责字段存在性、类型、长度、数组结构校验。
+- 分页字段属于公共字段，统一从公共 `FormRequest` 的分页规则复用，不要在业务 Request 里重复写 `page/per_page/pageSize/limit`。
+- 同一个 Request 可按路由 action 分发规则，但规则必须清楚，不要把无关接口揉在一起。
+- 字段名转换继续使用项目现有 `getSnakeRequest()`，不要在 Controller 里手写大小写映射。
+- Vue3 表单常见小驼峰字段会由公共 `FormRequest::prepareForValidation()` 补齐下划线字段；业务 Request 只写数据库/模型一致的下划线规则。
+- 批量 ID 解析统一使用公共 `FormRequest::integerIds()`，不要在每个 Controller 里重复写数组过滤。
+
+## Service
+
+- Service 只处理业务算法和跨模型业务流程。
+- Service 不吞异常。数据坏了就直接暴露，避免返回空数组造成误判。
+- 变量名不能复用不同含义，比如模型变量和转换结果不能都叫 `$serverPath`。
+- 入参类型能明确就明确，例如数组入参写 `array`，返回数组写 `: array`。
+
+## 返回与异常
+
+- 资源型返回走 `BaseResource` 或 `$this->resource()`。
+- 纯动作接口成功可返回空 JSON：`response()->json([])`。
+- 下载、导出、上传等特殊接口按语义返回，不强行套 CRUD 风格。
+- 参数错误优先由 Request 返回 422；业务不成立直接抛异常，不做兼容式补丁。
+
+## 测试
+
+- 改 Controller 必须补最小范围 Feature 测试。
+- 测试先覆盖稳定契约，再覆盖这次真正改动的业务结果。
+- 后端运行验证以远端环境为准；本地只做语法检查和必要的快速反馈。
+
+## ServerPath 样板
+
+`ServerPathController` 是当前后台 CRUD 新样板：
+
+- `ServerPathRequest` 负责 `add/edit/convert/batchDelete` 校验。
+- `ServerPathRequest` 同时负责 `index` 查询参数校验，分页字段来自公共 `FormRequest`，业务字段只保留 `code/name/filter`。
+- `ServerPathController` 负责列表、详情、新增、编辑、删除、转换的 HTTP 编排。
+- `ServerPathController@index` 用显式 `QueryBuilder::for()` 展示列表查询结构：允许过滤、排序、分页都写在当前方法里；返回继续走 `$this->resource()`。
+- `ServerPathService` 负责路径转换算法，并在 `sources` JSON 错误时直接暴露异常。

--- a/tests/Feature/Api/Admin/DashboardStatsTest.php
+++ b/tests/Feature/Api/Admin/DashboardStatsTest.php
@@ -168,6 +168,13 @@ class DashboardStatsTest extends TestCase
         $this->assertIsInt($response->json('data.matrix.rows.0.cells.0'));
     }
 
+    /**
+     * 创建仪表盘测试表结构。
+     *
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
     private function createDashboardSchema(): void
     {
         Schema::create('users', function (Blueprint $table) {
@@ -221,6 +228,21 @@ class DashboardStatsTest extends TestCase
             $table->unsignedInteger('update_user')->default(0);
             $table->unsignedInteger('updated_at')->default(0);
             $table->unsignedInteger('deleted_at')->default(0);
+        });
+
+        Schema::create('work_daily_tags', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 50);
+            $table->unsignedInteger('create_user')->default(0);
+            $table->unsignedInteger('created_at')->default(0);
+            $table->unsignedInteger('update_user')->default(0);
+            $table->unsignedInteger('updated_at')->default(0);
+            $table->unsignedInteger('deleted_at')->default(0);
+        });
+
+        Schema::create('work_daily_log_tag', function (Blueprint $table) {
+            $table->unsignedBigInteger('work_daily_log_id')->default(0);
+            $table->unsignedBigInteger('work_daily_tag_id')->default(0);
         });
 
         Schema::create('work_docs', function (Blueprint $table) {

--- a/tests/Feature/Api/Admin/ServerPathControllerTest.php
+++ b/tests/Feature/Api/Admin/ServerPathControllerTest.php
@@ -1,0 +1,249 @@
+<?php
+
+use App\Models\Admin\ServerPath;
+use App\Models\User\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    Config::set('database.default', 'sqlite');
+    Config::set('database.connections.sqlite.database', ':memory:');
+    DB::purge('sqlite');
+    DB::setDefaultConnection('sqlite');
+
+    Schema::dropAllTables();
+
+    Schema::create('users', function (Blueprint $table) {
+        $table->id();
+        $table->string('username')->nullable();
+        $table->string('email')->nullable()->unique();
+        $table->string('phone')->nullable()->unique();
+        $table->string('openid')->nullable()->unique();
+        $table->string('unionid')->nullable()->unique();
+        $table->string('password')->nullable();
+        $table->timestamp('email_verified_at')->nullable();
+        $table->integer('status')->default(0);
+        $table->rememberToken();
+        $table->unsignedInteger('created_at')->default(0);
+        $table->integer('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+
+    Schema::create('roles', function (Blueprint $table) {
+        $table->id();
+        $table->string('name')->nullable();
+        $table->string('code')->nullable();
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+
+    Schema::create('user_role', function (Blueprint $table) {
+        $table->unsignedBigInteger('user_id')->default(0);
+        $table->unsignedBigInteger('role_id')->default(0);
+    });
+
+    Schema::create('server_paths', function (Blueprint $table) {
+        $table->id();
+        $table->string('code')->index();
+        $table->string('name')->index();
+        $table->string('url', 120)->nullable();
+        $table->text('target');
+        $table->text('sources');
+        $table->integer('sort');
+        $table->unsignedInteger('created_at')->default(0);
+        $table->unsignedInteger('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+});
+
+it('新增服务器路径时编码 sources', function () {
+    $token = serverPathLoginAsAdmin();
+
+    $response = $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->postJson('/api/server-path/add', [
+            'code' => 'blog',
+            'name' => '博客项目',
+            'url' => 'https://blog.example.test',
+            'target' => '/data/personal/projects/blog',
+            'sources' => ['/Volumes/AgentAPFS/Program/Personal/blog'],
+            'sort' => 10,
+        ]);
+
+    $response
+        ->assertOk()
+        ->assertJsonPath('code', 0)
+        ->assertJsonPath('data.code', 'blog')
+        ->assertJsonPath('data.sort', 10);
+
+    $serverPath = ServerPath::query()->where('code', 'blog')->firstOrFail();
+
+    expect(json_decode($serverPath->sources, true))
+        ->toBe(['/Volumes/AgentAPFS/Program/Personal/blog']);
+});
+
+it('列表接口兼容前端查询参数', function () {
+    $token = serverPathLoginAsAdmin();
+    serverPathCreate(['name' => '博客后端', 'sort' => 2]);
+    serverPathCreate(['name' => '个人前端', 'sort' => 1]);
+
+    $response = $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->getJson('/api/server-path/index?' . http_build_query([
+            'page' => 1,
+            'per_page' => 1,
+            'name' => '博客',
+        ]));
+
+    $response
+        ->assertOk()
+        ->assertJsonPath('code', 0)
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.name', '博客后端')
+        ->assertJsonPath('count', 1);
+});
+
+it('编辑服务器路径时不使用 Controller 兜底值', function () {
+    $token = serverPathLoginAsAdmin();
+    $serverPath = serverPathCreate([
+        'sources' => json_encode(['/old/path']),
+        'sort' => 1,
+    ]);
+
+    $response = $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->postJson("/api/server-path/{$serverPath->id}", [
+            'code' => 'blog-api',
+            'name' => '博客后端',
+            'url' => 'https://api.example.test',
+            'target' => '/data/personal/projects/blog-api',
+            'sources' => ['/new/path'],
+            'sort' => 20,
+        ]);
+
+    $response
+        ->assertOk()
+        ->assertJsonPath('code', 0)
+        ->assertJsonPath('data.code', 'blog-api')
+        ->assertJsonPath('data.sort', 20);
+
+    $serverPath->refresh();
+
+    expect(json_decode($serverPath->sources, true))
+        ->toBe(['/new/path'])
+        ->and($serverPath->url)
+        ->toBe('https://api.example.test');
+});
+
+it('转换接口返回服务层转换结果', function () {
+    $token = serverPathLoginAsAdmin();
+    $serverPath = serverPathCreate([
+        'target' => '/mnt/server',
+        'sources' => json_encode(['C:\\project']),
+    ]);
+
+    $response = $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->postJson("/api/server-path/convert/{$serverPath->id}", [
+            'paths' => [
+                'C:\\project\\app\\index.php',
+                '/unchanged/path',
+            ],
+        ]);
+
+    $response
+        ->assertOk()
+        ->assertJsonPath('code', 0)
+        ->assertJsonPath('data.0', '/mnt/server/app/index.php')
+        ->assertJsonPath('data.1', '/unchanged/path');
+});
+
+it('批量删除接口支持多个 ID', function () {
+    $token = serverPathLoginAsAdmin();
+    $first = serverPathCreate(['code' => 'first']);
+    $second = serverPathCreate(['code' => 'second']);
+
+    $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->postJson('/api/server-path/delete', ['id' => [$first->id, $second->id]])
+        ->assertOk()
+        ->assertJsonPath('code', 0);
+
+    serverPathAssertSoftDeleted($first->id);
+    serverPathAssertSoftDeleted($second->id);
+});
+
+/**
+ * 创建后台管理员登录令牌。
+ *
+ * @return string
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/5/26
+ */
+function serverPathLoginAsAdmin(): string
+{
+    $admin = User::query()->create([
+        'username' => 'server_path_admin',
+        'email' => 'server-path-admin@example.com',
+        'phone' => '13800000012',
+        'password' => bcrypt('password'),
+        'status' => 1,
+    ]);
+
+    $roleId = DB::table('roles')->insertGetId([
+        'name' => '超级管理员',
+        'code' => 'super',
+        'deleted_at' => 0,
+    ]);
+
+    DB::table('user_role')->insert([
+        'user_id' => $admin->id,
+        'role_id' => $roleId,
+    ]);
+
+    return auth('api')->login($admin);
+}
+
+/**
+ * 创建服务器路径测试数据。
+ *
+ * @param array $attributes
+ * @return ServerPath
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/5/26
+ */
+function serverPathCreate(array $attributes = []): ServerPath
+{
+    return ServerPath::query()->create(array_merge([
+        'code' => 'blog',
+        'name' => '博客项目',
+        'url' => '',
+        'target' => '/data/personal/projects/blog',
+        'sources' => json_encode(['/Volumes/AgentAPFS/Program/Personal/blog']),
+        'sort' => 0,
+        'created_at' => time(),
+        'updated_at' => time(),
+        'deleted_at' => 0,
+    ], $attributes));
+}
+
+/**
+ * 断言服务器路径已软删除。
+ *
+ * @param int $id
+ * @return void
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/5/26
+ */
+function serverPathAssertSoftDeleted(int $id): void
+{
+    $deletedAt = DB::table('server_paths')->where('id', $id)->value('deleted_at');
+
+    expect($deletedAt)->toBeGreaterThan(0);
+}

--- a/tests/Feature/Api/Admin/TodoItemControllerTest.php
+++ b/tests/Feature/Api/Admin/TodoItemControllerTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Api\Admin;
-
 use App\Models\Admin\TodoItem;
 use App\Models\User\User;
 use Illuminate\Database\Schema\Blueprint;
@@ -10,162 +8,193 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
-class TodoItemControllerTest extends TestCase
-{
-    protected function setUp(): void
-    {
-        parent::setUp();
+uses(TestCase::class);
 
-        Config::set('database.default', 'sqlite');
-        Config::set('database.connections.sqlite.database', ':memory:');
-        DB::purge('sqlite');
-        DB::setDefaultConnection('sqlite');
+beforeEach(function () {
+    Config::set('database.default', 'sqlite');
+    Config::set('database.connections.sqlite.database', ':memory:');
+    DB::purge('sqlite');
+    DB::setDefaultConnection('sqlite');
 
-        Schema::dropAllTables();
+    Schema::dropAllTables();
 
-        Schema::create('users', function (Blueprint $table) {
-            $table->id();
-            $table->string('username')->nullable();
-            $table->string('email')->nullable()->unique();
-            $table->string('phone')->nullable()->unique();
-            $table->string('openid')->nullable()->unique();
-            $table->string('unionid')->nullable()->unique();
-            $table->string('password')->nullable();
-            $table->timestamp('email_verified_at')->nullable();
-            $table->integer('status')->default(0);
-            $table->rememberToken();
-            $table->unsignedInteger('created_at')->default(0);
-            $table->integer('update_user')->default(0);
-            $table->unsignedInteger('updated_at')->default(0);
-            $table->unsignedInteger('deleted_at')->default(0);
-        });
+    Schema::create('users', function (Blueprint $table) {
+        $table->id();
+        $table->string('username')->nullable();
+        $table->string('email')->nullable()->unique();
+        $table->string('phone')->nullable()->unique();
+        $table->string('openid')->nullable()->unique();
+        $table->string('unionid')->nullable()->unique();
+        $table->string('password')->nullable();
+        $table->timestamp('email_verified_at')->nullable();
+        $table->integer('status')->default(0);
+        $table->rememberToken();
+        $table->unsignedInteger('created_at')->default(0);
+        $table->integer('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
 
-        Schema::create('roles', function (Blueprint $table) {
-            $table->id();
-            $table->string('name')->nullable();
-            $table->string('code')->nullable();
-            $table->unsignedInteger('deleted_at')->default(0);
-        });
+    Schema::create('roles', function (Blueprint $table) {
+        $table->id();
+        $table->string('name')->nullable();
+        $table->string('code')->nullable();
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
 
-        Schema::create('user_role', function (Blueprint $table) {
-            $table->unsignedBigInteger('user_id')->default(0);
-            $table->unsignedBigInteger('role_id')->default(0);
-        });
+    Schema::create('user_role', function (Blueprint $table) {
+        $table->unsignedBigInteger('user_id')->default(0);
+        $table->unsignedBigInteger('role_id')->default(0);
+    });
 
-        Schema::create('work_platforms', function (Blueprint $table) {
-            $table->id();
-            $table->string('name', 50)->index();
-            $table->boolean('status')->default(1);
-            $table->smallInteger('sort')->default(0);
-            $table->unsignedInteger('create_user')->default(0);
-            $table->unsignedInteger('created_at')->default(0);
-            $table->unsignedInteger('update_user')->default(0);
-            $table->unsignedInteger('updated_at')->default(0);
-            $table->unsignedInteger('deleted_at')->default(0);
-        });
+    Schema::create('work_platforms', function (Blueprint $table) {
+        $table->id();
+        $table->string('name', 50)->index();
+        $table->boolean('status')->default(1);
+        $table->smallInteger('sort')->default(0);
+        $table->unsignedInteger('create_user')->default(0);
+        $table->unsignedInteger('created_at')->default(0);
+        $table->unsignedInteger('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
 
-        Schema::create('todo_items', function (Blueprint $table) {
-            $table->id();
-            $table->string('title', 255);
-            $table->text('content')->nullable();
-            $table->unsignedTinyInteger('status')->default(0)->index();
-            $table->unsignedTinyInteger('priority')->default(1)->index();
-            $table->date('due_date')->nullable()->index();
-            $table->text('tags')->nullable();
-            $table->unsignedBigInteger('platform_id')->default(0)->index();
-            $table->unsignedInteger('create_user')->default(0);
-            $table->unsignedInteger('created_at')->default(0);
-            $table->unsignedInteger('update_user')->default(0);
-            $table->unsignedInteger('updated_at')->default(0);
-            $table->unsignedInteger('deleted_at')->default(0);
-        });
-    }
+    Schema::create('todo_items', function (Blueprint $table) {
+        $table->id();
+        $table->string('title', 255);
+        $table->text('content')->nullable();
+        $table->unsignedTinyInteger('status')->default(0)->index();
+        $table->unsignedTinyInteger('priority')->default(1)->index();
+        $table->date('due_date')->nullable()->index();
+        $table->text('tags')->nullable();
+        $table->unsignedBigInteger('platform_id')->default(0)->index();
+        $table->unsignedInteger('create_user')->default(0);
+        $table->unsignedInteger('created_at')->default(0);
+        $table->integer('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+});
 
-    public function test_statistics_counts_canceled_todo_items(): void
-    {
-        $admin = $this->createSuperAdmin();
+it('统计接口包含已取消待办数量', function () {
+    $admin = todoLoginAsSuperAdmin();
 
-        $this->createTodo(['status' => 0]);
-        $this->createTodo(['status' => 1]);
-        $this->createTodo(['status' => 2]);
-        $this->createTodo(['status' => 3]);
+    todoCreate(['status' => 0]);
+    todoCreate(['status' => 1]);
+    todoCreate(['status' => 2]);
+    todoCreate(['status' => 3]);
 
-        $response = $this
-            ->withHeader('Authorization', 'Bearer ' . auth('api')->login($admin))
-            ->getJson('/api/todo/statistics');
+    $response = $this
+        ->withHeader('Authorization', 'Bearer ' . auth('api')->login($admin))
+        ->getJson('/api/todo/statistics');
 
-        $response
-            ->assertOk()
-            ->assertJsonPath('code', 0)
-            ->assertJsonPath('data.total', 4)
-            ->assertJsonPath('data.pending', 1)
-            ->assertJsonPath('data.inProgress', 1)
-            ->assertJsonPath('data.completed', 1)
-            ->assertJsonPath('data.canceled', 1);
-    }
+    $response
+        ->assertOk()
+        ->assertJsonPath('code', 0)
+        ->assertJsonPath('data.total', 4)
+        ->assertJsonPath('data.pending', 1)
+        ->assertJsonPath('data.inProgress', 1)
+        ->assertJsonPath('data.completed', 1)
+        ->assertJsonPath('data.canceled', 1);
+});
 
-    public function test_edit_rejects_blank_title(): void
-    {
-        $admin = $this->createSuperAdmin();
-        $todo = $this->createTodo(['title' => '原始标题', 'create_user' => $admin->id]);
+it('编辑待办时由 Request 拒绝空标题', function () {
+    $admin = todoLoginAsSuperAdmin();
+    $todo = todoCreate(['title' => '原始标题', 'create_user' => $admin->id]);
 
-        $this->withoutExceptionHandling();
-
-        try {
-            $this
-                ->withHeader('Authorization', 'Bearer ' . auth('api')->login($admin))
-                ->postJson("/api/todo/{$todo->id}", [
-                    'title' => '   ',
-                ]);
-
-            $this->fail('编辑待办时应拒绝空标题');
-        } catch (\Exception $exception) {
-            $this->assertSame('标题不能为空', $exception->getMessage());
-        }
-
-        $this->assertDatabaseHas('todo_items', [
-            'id' => $todo->id,
-            'title' => '原始标题',
+    $response = $this
+        ->withHeader('Authorization', 'Bearer ' . auth('api')->login($admin))
+        ->postJson("/api/todo/{$todo->id}", [
+            'title' => '   ',
         ]);
-    }
 
-    private function createSuperAdmin(): User
-    {
-        $admin = User::query()->create([
-            'username' => 'todo_admin',
-            'email' => 'todo-admin@example.com',
-            'phone' => '13800000000',
-            'password' => bcrypt('password'),
+    $response
+        ->assertOk()
+        ->assertJsonPath('code', 422);
+
+    $this->assertDatabaseHas('todo_items', [
+        'id' => $todo->id,
+        'title' => '原始标题',
+    ]);
+});
+
+it('新增待办时接收 Vue3 下划线表单参数和 Vue2 分页参数', function () {
+    $admin = todoLoginAsSuperAdmin();
+    $token = auth('api')->login($admin);
+
+    $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->postJson('/api/todo/add', [
+            'title' => '统一接口风格',
+            'content' => '补 Request 校验',
+            'priority' => 2,
             'status' => 1,
-        ]);
-
-        $roleId = DB::table('roles')->insertGetId([
-            'name' => '超级管理员',
-            'code' => 'super',
-            'deleted_at' => 0,
-        ]);
-
-        DB::table('user_role')->insert([
-            'user_id' => $admin->id,
-            'role_id' => $roleId,
-        ]);
-
-        return $admin;
-    }
-
-    private function createTodo(array $attributes = []): TodoItem
-    {
-        return TodoItem::query()->create(array_merge([
-            'title' => '测试待办',
-            'content' => '测试内容',
-            'status' => 0,
-            'priority' => 1,
             'platform_id' => 0,
-            'create_user' => 0,
-            'update_user' => 0,
-            'created_at' => time(),
-            'updated_at' => time(),
-            'deleted_at' => 0,
-        ], $attributes));
-    }
+            'tags' => ['backend'],
+        ])
+        ->assertOk()
+        ->assertJsonPath('code', 0)
+        ->assertJsonPath('data.title', '统一接口风格');
+
+    $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->getJson('/api/todo/index?page=1&limit=1&keyword=统一')
+        ->assertOk()
+        ->assertJsonPath('code', 0)
+        ->assertJsonCount(1, 'data');
+});
+
+/**
+ * 创建超级管理员。
+ *
+ * @return User
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/5/26
+ */
+function todoLoginAsSuperAdmin(): User
+{
+    $admin = User::query()->create([
+        'username' => 'todo_admin',
+        'email' => 'todo-admin@example.com',
+        'phone' => '13800000000',
+        'password' => bcrypt('password'),
+        'status' => 1,
+    ]);
+
+    $roleId = DB::table('roles')->insertGetId([
+        'name' => '超级管理员',
+        'code' => 'super',
+        'deleted_at' => 0,
+    ]);
+
+    DB::table('user_role')->insert([
+        'user_id' => $admin->id,
+        'role_id' => $roleId,
+    ]);
+
+    return $admin;
+}
+
+/**
+ * 创建待办测试数据。
+ *
+ * @param array $attributes
+ * @return TodoItem
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/5/26
+ */
+function todoCreate(array $attributes = []): TodoItem
+{
+    return TodoItem::query()->create(array_merge([
+        'title' => '测试待办',
+        'content' => '测试内容',
+        'status' => 0,
+        'priority' => 1,
+        'platform_id' => 0,
+        'create_user' => 0,
+        'update_user' => 0,
+        'created_at' => time(),
+        'updated_at' => time(),
+        'deleted_at' => 0,
+    ], $attributes));
 }

--- a/tests/Feature/Api/User/UpdateUserInfoTest.php
+++ b/tests/Feature/Api/User/UpdateUserInfoTest.php
@@ -3,13 +3,34 @@
 namespace Tests\Feature\Api\User;
 
 use App\Models\User\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
 class UpdateUserInfoTest extends TestCase
 {
-    use RefreshDatabase;
+    protected function setUp(): void
+    {
+        parent::setUp();
 
+        Config::set('database.default', 'sqlite');
+        Config::set('database.connections.sqlite.database', ':memory:');
+        DB::purge('sqlite');
+        DB::setDefaultConnection('sqlite');
+
+        Schema::dropAllTables();
+        $this->createProfileSchema();
+    }
+
+    /**
+     * 当前用户资料可更新，并在会员信息缺失时创建会员。
+     *
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
     public function test_current_user_profile_can_be_updated_and_member_is_created_when_missing(): void
     {
         $user = User::query()->create([
@@ -20,8 +41,10 @@ class UpdateUserInfoTest extends TestCase
             'status' => 1,
         ]);
 
+        $token = auth('api')->login($user);
+
         $response = $this
-            ->actingAs($user, 'api')
+            ->withHeader('Authorization', "Bearer {$token}")
             ->postJson('/api/index/updateUserInfo', [
                 'avatar' => '',
                 'email' => 'after@example.com',
@@ -34,7 +57,7 @@ class UpdateUserInfoTest extends TestCase
             ]);
 
         $response
-            ->assertStatus(201)
+            ->assertOk()
             ->assertJsonPath('code', 0)
             ->assertJsonPath('data.email', 'after@example.com')
             ->assertJsonPath('data.phone', '13900000000')
@@ -56,5 +79,89 @@ class UpdateUserInfoTest extends TestCase
             'address' => '浙江杭州',
             'intro' => 'profile intro',
         ]);
+    }
+
+    /**
+     * 创建个人资料测试表结构。
+     *
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/26
+     */
+    private function createProfileSchema(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('username')->nullable();
+            $table->string('email')->nullable()->unique();
+            $table->string('phone')->nullable()->unique();
+            $table->string('openid')->nullable()->unique();
+            $table->string('unionid')->nullable()->unique();
+            $table->string('password')->nullable();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->integer('status')->default(0);
+            $table->rememberToken();
+            $table->unsignedInteger('created_at')->default(0);
+            $table->integer('update_user')->default(0);
+            $table->unsignedInteger('updated_at')->default(0);
+            $table->unsignedInteger('deleted_at')->default(0);
+        });
+
+        Schema::create('members', function (Blueprint $table) {
+            $table->id();
+            $table->string('user_id', 50)->nullable();
+            $table->smallInteger('member_level')->default(0);
+            $table->string('realname', 50)->nullable();
+            $table->string('nickname', 50)->nullable();
+            $table->tinyInteger('gender')->default(3);
+            $table->string('avatar', 180)->default('');
+            $table->unsignedInteger('birthday')->default(0);
+            $table->string('province_code', 30)->nullable();
+            $table->string('city_code', 30)->nullable();
+            $table->string('district_code', 30)->nullable();
+            $table->string('address')->nullable();
+            $table->text('intro')->nullable();
+            $table->string('signature', 30)->nullable();
+            $table->string('admire')->nullable();
+            $table->boolean('device')->default(0);
+            $table->string('device_code', 40)->nullable();
+            $table->string('push_alias', 40)->default('');
+            $table->boolean('source')->default(1);
+            $table->boolean('status')->default(1);
+            $table->string('app_version', 30)->default('');
+            $table->string('code', 10)->nullable();
+            $table->string('login_ip', 30)->nullable();
+            $table->unsignedInteger('login_at')->default(0);
+            $table->string('login_region', 20)->nullable();
+            $table->unsignedInteger('login_count')->default(0);
+            $table->integer('create_user')->default(0);
+            $table->unsignedInteger('created_at')->default(0);
+            $table->integer('update_user')->default(0);
+            $table->unsignedInteger('updated_at')->default(0);
+            $table->unsignedInteger('deleted_at')->default(0);
+        });
+
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->string('code')->nullable();
+            $table->unsignedInteger('deleted_at')->default(0);
+        });
+
+        Schema::create('menus', function (Blueprint $table) {
+            $table->id();
+            $table->string('permission')->nullable();
+            $table->unsignedInteger('deleted_at')->default(0);
+        });
+
+        Schema::create('user_role', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->default(0);
+            $table->unsignedBigInteger('role_id')->default(0);
+        });
+
+        Schema::create('role_menu', function (Blueprint $table) {
+            $table->unsignedBigInteger('role_id')->default(0);
+            $table->unsignedBigInteger('menu_id')->default(0);
+        });
     }
 }


### PR DESCRIPTION
## 改动内容

- 统一后台 Admin/User 相关接口的 Controller/Request 写法。
- 新增业务 Request，参数校验、分页字段、批量 ID 解析统一收口。
- 更新后端 Controller 代码风格规范，明确简单列表和复杂列表的查询写法。
- 保留微信小程序、烟草、captcha、qiniu、weather、公开 Web、小程序非后台特殊接口不改。

## 关键规范

- Controller 只做 HTTP 编排，参数校验进入 Request。
- 简单列表可以用公共查询封装，复杂列表显式使用 QueryBuilder 组装查询。
- 返回模型、集合、分页结果统一走 `$this->resource()`。
- 分页统一使用 `$request->perPage()`。
- Vue2/Vue3 参数差异由公共 FormRequest 处理。

## 验证

- `git diff --check`
- 远端 `/data/personal/projects/blog` 执行：`vendor/bin/sail artisan test tests/Feature/Api/Admin tests/Feature/Api/User`
- 结果：27 passed, 1 skipped, 148 assertions
