### PR TITLE
fix: getUserInfo 强制 eager-load roles 关系

### DIFF
--- a/app/Http/Controllers/Api/User/UsersController.php
+++ b/app/Http/Controllers/Api/User/UsersController.php
@@ -234,7 +234,7 @@ class UsersController extends Controller
     protected function loadCurrentUserProfile()
     {
         $user = auth()->user();
-        $user = QueryBuilder::for(User::class)->allowedIncludes('member')->where(['id' => $user->id])->first();
+        $user = QueryBuilder::for(User::class)->allowedIncludes('member')->with('roles')->where(['id' => $user->id])->first();
         if ($user && $user->member) {
             $user->member->avatar = $user->member->avatar
                 ? $this->qiniuService->getPrivateUrl($user->member->avatar)


### PR DESCRIPTION
## 背景

前端 `hasPerm` 指令有两条放行路径：

- **路径 A**：`userInfo.roles.includes("super")` → 超管直接放行
- **路径 B**：`userInfo.perms` 包含具体权限码 → 按需放行

线上验证 `/users/getUserInfo` 实际响应：**`roles` 字段缺失，路径 A 永远不会触发**。所有超管的权限校验只能依赖路径 B（`perms` 全量数组）兜底，遇到某个权限码漏 seed、或 `user_role` 表数据异常时会被静默拦截。

## 根因

`UsersController::loadCurrentUserProfile()` 用的是：

```php
QueryBuilder::for(User::class)->allowedIncludes('member')->where(...)->first();
```

`UserResource::toArray()` 里 `roles` 字段走 `$this->whenLoaded('roles', ...)` —— 关系没被 eager-load 就不会出现在响应里。`allowedIncludes` 没列 `roles`，前端调用也没传 `?include=roles`，所以 `roles` 字段始终缺失。

## 改动

`app/Http/Controllers/Api/User/UsersController.php`：在 `loadCurrentUserProfile()` 里强制 `->with('roles')`，让响应固定带 `roles` 字段，不依赖前端传 include 参数。

```diff
-$user = QueryBuilder::for(User::class)->allowedIncludes('member')->where(['id' => $user->id])->first();
+$user = QueryBuilder::for(User::class)->allowedIncludes('member')->with('roles')->where(['id' => $user->id])->first();
```

## 影响面

- `/users/getUserInfo`、`updateUserInfo` 这两个走 `loadCurrentUserProfile()` 的接口，响应里固定多一个 `roles: [{code, name, ...}]` 字段。
- 前端 `store/modules/user.ts` 已有的映射逻辑（`raw.roles.map(r => r.code || r.name)`）会正确把 super 写进 `userInfo.roles`，`hasPerm` 路径 A 生效。
- 不影响非超管用户：普通角色走路径 B，照常按 perms 校验。

## 测试计划

- [ ] 远端同步 `main` 后用 zxf 账号刷新页面，浏览器 console 检查 `userStore.userInfo.roles` 是否包含 `"super"`
- [ ] 菜单管理页操作按钮、状态开关、工具栏添加按钮持续可见
- [ ] 普通管理员账号（admin）登录后 perms 校验仍然按权限码工作