### PR TITLE
feat(user): 新增「未关联会员的用户」接口

### DIFF
--- a/app/Http/Controllers/Api/User/UsersController.php
+++ b/app/Http/Controllers/Api/User/UsersController.php
@@ -43,6 +43,22 @@ class UsersController extends Controller
     }
 
     /**
+     * 获取未关联会员的用户列表
+     *
+     * @return BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/5/29
+     */
+    public function unbound()
+    {
+        $users = QueryBuilder::for(User::class)
+            ->whereDoesntHave('member')
+            ->get(['id', 'username', 'phone', 'email']);
+
+        return new BaseResource($users);
+    }
+
+    /**
      * 获取用户详情
      *
      * @param User $user

--- a/routes/api.php
+++ b/routes/api.php
@@ -136,6 +136,8 @@ Route::name('api')->group(function () {
         Route::get('users/list', [UsersController::class, 'index'])->name('users.index');
         // 验证用户
         Route::get('users/checkUser', [UsersController::class, 'checkUser'])->name('users.checkUser');
+        // 未关联会员的用户列表
+        Route::get('users/unbound', [UsersController::class, 'unbound'])->name('users.unbound');
         // 用户详情
         Route::get('users/{user}', [UsersController::class, 'show'])->name('users.show');
         // 创建用户


### PR DESCRIPTION
## 背景
会员是用户的扩展资料，二者一对一（`User hasOne Member`）。后台「新增会员」需从**未绑定会员的用户**中选择关联对象，原先缺少该数据来源接口。

## 改动
- `UsersController::unbound()`：用 `QueryBuilder::for(User::class)->whereDoesntHave('member')` 取未关联会员的用户，返回精简字段 `id/username/phone/email`，不分页（用户量小）。
- `routes/api.php`：注册 `GET users/unbound`，置于 `users/{user}` 通配路由**之前**，避免被通配吞掉。仅 `auth:api` 鉴权，与现有 users 接口一致。

## 测试计划
- [x] 远端 `route:list` 确认路由存在
- [x] JWT curl `GET /api/users/unbound` 返回未关联用户列表
- [x] 新增会员绑定用户后，该用户从 unbound 列表消失