### PR TITLE
feat(dashboard): 连续打卡改为按工作日统计，周末不断签

### DIFF
--- a/app/Services/Api/Admin/Dashboard/StatsAggregator.php
+++ b/app/Services/Api/Admin/Dashboard/StatsAggregator.php
@@ -258,19 +258,25 @@ class StatsAggregator
      */
     private function calculateStreaks(array $dates, string $endDate): array
     {
-        if (empty($dates)) {
+        // 周末（周六、周日）中性跳过：不计入连续口径，也不打断连续
+        $workdayDates = array_values(array_filter(
+            $dates,
+            fn ($date) => !Carbon::parse($date)->isWeekend()
+        ));
+
+        if (empty($workdayDates)) {
             return [0, 0, ['start' => null, 'end' => null]];
         }
 
-        $currentStreak = 0;
         $longestStreak = 0;
         $longestRange = ['start' => null, 'end' => null];
         $currentRun = 0;
         $runStart = null;
         $previous = null;
 
-        foreach ($dates as $date) {
-            if ($previous && Carbon::parse($previous)->addDay()->toDateString() === $date) {
+        foreach ($workdayDates as $date) {
+            // 相邻判定按“下一个工作日”：周五的下一个工作日是周一，跨周末不断
+            if ($previous && $this->nextWorkday($previous) === $date) {
                 $currentRun++;
             } else {
                 $currentRun = 1;
@@ -285,17 +291,77 @@ class StatsAggregator
             $previous = $date;
         }
 
-        $lastDate = end($dates);
-        if ($lastDate === $endDate) {
-            $currentStreak = 1;
-            $currentDate = Carbon::parse($lastDate);
-            while (in_array($currentDate->copy()->subDay()->toDateString(), $dates, true)) {
-                $currentStreak++;
-                $currentDate->subDay();
-            }
-        }
+        $currentStreak = $this->currentWorkdayStreak($workdayDates, $endDate);
 
         return [$currentStreak, $longestStreak, $longestRange];
+    }
+
+    /**
+     * 计算当前连续工作日数。工作日当天未写则归零（保留催写语义），周末则保留上一个工作日的连续。
+     *
+     * @param array $workdayDates 升序排列、仅含工作日的活跃日期
+     * @param string $endDate 基准日（通常为今天）
+     * @return int
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/1
+     */
+    private function currentWorkdayStreak(array $workdayDates, string $endDate): int
+    {
+        // 基准工作日：今天是工作日则取今天，今天是周末则回看上一个工作日
+        $anchor = Carbon::parse($endDate)->isWeekend()
+            ? $this->previousWorkday($endDate)
+            : $endDate;
+
+        $lastActive = end($workdayDates);
+        if ($lastActive !== $anchor) {
+            return 0;
+        }
+
+        $lookup = array_flip($workdayDates);
+        $streak = 1;
+        $cursor = $lastActive;
+        while (isset($lookup[$prev = $this->previousWorkday($cursor)])) {
+            $streak++;
+            $cursor = $prev;
+        }
+
+        return $streak;
+    }
+
+    /**
+     * 取指定日期之后的下一个工作日（跳过周六、周日）。
+     *
+     * @param string $date
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/1
+     */
+    private function nextWorkday(string $date): string
+    {
+        $cursor = Carbon::parse($date)->addDay();
+        while ($cursor->isWeekend()) {
+            $cursor->addDay();
+        }
+
+        return $cursor->toDateString();
+    }
+
+    /**
+     * 取指定日期之前的上一个工作日（跳过周六、周日）。
+     *
+     * @param string $date
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/1
+     */
+    private function previousWorkday(string $date): string
+    {
+        $cursor = Carbon::parse($date)->subDay();
+        while ($cursor->isWeekend()) {
+            $cursor->subDay();
+        }
+
+        return $cursor->toDateString();
     }
 
     private function calculatePeakHour(Collection $logs): array

--- a/docs/standards/backend-controller-style.md
+++ b/docs/standards/backend-controller-style.md
@@ -50,6 +50,15 @@ Controller 只负责接 HTTP 请求、调用业务对象、返回响应。参数
 - 测试先覆盖稳定契约，再覆盖这次真正改动的业务结果。
 - 后端运行验证以远端环境为准；本地只做语法检查和必要的快速反馈。
 
+### 测试格式（Pest）
+
+- 测试文件统一用 **Pest** 格式：文件顶部 `uses(Tests\TestCase::class);`，用例写成 `it('中文描述', function () { ... });`，断言优先用 `expect()->toBe()/toEqual()/toHaveCount()` 等链式风格，HTTP 断言仍可用 `$this->getJson(...)->assertJsonPath(...)`（`it` 闭包内 `$this` 即 `TestCase`）。新样板参考 `ServerPathControllerTest`、`TodoItemControllerTest`、`StatsAggregatorTest`。
+- **不要在 Pest 文件里写 PHPUnit 类**（`it()`/`uses()` 等函数不能存在于 `extends TestCase` 的类里）。当需要改动一个仍是 PHPUnit 类风格的旧测试文件时，**整文件转成 Pest**，不要在同一文件混两种风格。
+- 类的 `setUp`/`tearDown` 对应 Pest 的 `beforeEach()`/`afterEach()`；类的私有辅助方法改为**带文件前缀的全局函数**（如 `dashboardCreateUser()`、`statsInvokeStreaks()`），前缀用于避免与其它 Pest 文件的全局函数重名。
+- 测试私有方法用 `ReflectionMethod`（`setAccessible(true)`）调用，不要为了可测性把私有方法改成 public。
+- 涉及“今天/当前时间”的用例必须用 `Carbon::setTestNow()` 钉死到**固定日期并注明周几**，并在 `afterEach()` 用 `Carbon::setTestNow()` 复位；**禁止用相对日期**（`Carbon::today()->subDay()` 等），否则结果随运行日漂移，在“按工作日”等口径下会变成 flaky 测试。
+- 本地 `vendor` 可能不含 `pest`（dev 依赖未装），后端测试一律在远端执行：`./vendor/bin/sail pest [文件路径]`。
+
 ## ServerPath 样板
 
 `ServerPathController` 是当前后台 CRUD 新样板：

--- a/tests/Feature/Api/Admin/DashboardStatsTest.php
+++ b/tests/Feature/Api/Admin/DashboardStatsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Api\Admin;
-
 use App\Models\User\User;
 use Carbon\Carbon;
 use Illuminate\Database\Schema\Blueprint;
@@ -10,395 +8,399 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
-class DashboardStatsTest extends TestCase
+uses(TestCase::class);
+
+beforeEach(function () {
+    Config::set('database.default', 'sqlite');
+    Config::set('database.connections.sqlite.database', ':memory:');
+    DB::purge('sqlite');
+    DB::setDefaultConnection('sqlite');
+
+    Schema::dropAllTables();
+    dashboardCreateSchema();
+});
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+it('未登录请求统计接口返回 401', function () {
+    $response = $this->getJson('/api/dashboard/stats');
+
+    $response
+        ->assertStatus(200)
+        ->assertJsonPath('code', 401);
+});
+
+it('非法 view 或 range 返回 422', function () {
+    $token = dashboardCreateToken();
+
+    $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->getJson('/api/dashboard/stats?view=bad')
+        ->assertStatus(200)
+        ->assertJsonPath('code', 422);
+
+    $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->getJson('/api/dashboard/stats?range=bad')
+        ->assertStatus(200)
+        ->assertJsonPath('code', 422);
+});
+
+it('空数据用户返回空指标结构并带 cache hit', function () {
+    $token = dashboardCreateToken();
+
+    $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->getJson('/api/dashboard/stats')
+        ->assertOk()
+        ->assertJsonPath('code', 0)
+        ->assertJsonPath('data.view', 'overview')
+        ->assertJsonPath('data.metrics.total_words.value', 0)
+        ->assertJsonPath('data.metrics.current_streak.value', 0)
+        ->assertJsonPath('data.metrics.favorite_platform', null)
+        ->assertJsonPath('data.cache_hit', false);
+
+    $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->getJson('/api/dashboard/stats')
+        ->assertOk()
+        ->assertJsonPath('code', 0)
+        ->assertJsonPath('data.cache_hit', true);
+});
+
+it('今天没写但昨天有日志时 current streak 为 0', function () {
+    // 钉死今天为周二（工作日），昨天为周一（工作日），避免工作日口径下随运行日漂移
+    Carbon::setTestNow(Carbon::parse('2026-06-02 10:00:00', 'Asia/Shanghai'));
+
+    $user = dashboardCreateUser();
+    dashboardAssignSuperRole($user);
+
+    $platformId = DB::table('work_platforms')->insertGetId([
+        'name' => 'Alpha',
+        'status' => 1,
+        'created_at' => time(),
+        'updated_at' => time(),
+        'deleted_at' => 0,
+    ]);
+
+    $yesterday = Carbon::today('Asia/Shanghai')->subDay();
+    DB::table('work_daily_logs')->insert([
+        'platform_id' => $platformId,
+        'log_date' => $yesterday->toDateString(),
+        'content' => json_encode([
+            'platforms' => [[
+                'platform_id' => $platformId,
+                'platform_name' => 'Alpha',
+                'content' => '昨天产出了一些内容',
+            ]],
+        ], JSON_UNESCAPED_UNICODE),
+        'create_user' => $user->id,
+        'created_at' => $yesterday->copy()->setHour(10)->timestamp,
+        'updated_at' => $yesterday->copy()->setHour(10)->timestamp,
+        'deleted_at' => 0,
+    ]);
+
+    $token = auth('api')->login($user);
+    $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->getJson('/api/dashboard/stats?range=7d')
+        ->assertOk()
+        ->assertJsonPath('code', 0)
+        ->assertJsonPath('data.metrics.current_streak.value', 0)
+        ->assertJsonPath('data.metrics.current_streak.hint', '今天还没写呢');
+});
+
+it('platform view 返回排行与矩阵', function () {
+    $user = dashboardCreateUser();
+    dashboardAssignSuperRole($user);
+
+    $platformId = DB::table('work_platforms')->insertGetId([
+        'name' => 'Gamma',
+        'status' => 1,
+        'created_at' => time(),
+        'updated_at' => time(),
+        'deleted_at' => 0,
+    ]);
+
+    DB::table('work_daily_logs')->insert([
+        'platform_id' => $platformId,
+        'log_date' => now()->toDateString(),
+        'content' => json_encode([
+            'platforms' => [[
+                'platform_id' => $platformId,
+                'platform_name' => 'Gamma',
+                'content' => '平台月度矩阵统计',
+            ]],
+        ], JSON_UNESCAPED_UNICODE),
+        'create_user' => $user->id,
+        'created_at' => Carbon::now('Asia/Shanghai')->setHour(10)->timestamp,
+        'updated_at' => Carbon::now('Asia/Shanghai')->setHour(10)->timestamp,
+        'deleted_at' => 0,
+    ]);
+
+    $token = auth('api')->login($user);
+    $response = $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->getJson('/api/dashboard/stats?view=platform&range=30d');
+
+    $response
+        ->assertOk()
+        ->assertJsonPath('code', 0)
+        ->assertJsonPath('data.view', 'platform')
+        ->assertJsonPath('data.rank.0.name', 'Gamma')
+        ->assertJsonPath('data.matrix.rows.0.name', 'Gamma');
+
+    expect($response->json('data.matrix.months'))->toHaveCount(12)
+        ->and($response->json('data.matrix.rows.0.cells'))->toHaveCount(12)
+        ->and($response->json('data.matrix.rows.0.cells.0'))->toBeInt();
+});
+
+it('overview 包含 hour dist 和 week dist', function () {
+    $user = dashboardCreateUser();
+    dashboardAssignSuperRole($user);
+
+    $platformId = DB::table('work_platforms')->insertGetId([
+        'name'       => 'TestPlatform',
+        'status'     => 1,
+        'created_at' => time(),
+        'updated_at' => time(),
+        'deleted_at' => 0,
+    ]);
+
+    // 在 10:00 (hour=10 CST) 写了一条日志
+    $logTs = Carbon::today('Asia/Shanghai')->setHour(10)->timestamp;
+    DB::table('work_daily_logs')->insert([
+        'platform_id' => $platformId,
+        'log_date'    => now()->toDateString(),
+        'content'     => json_encode([
+            'platforms' => [[
+                'platform_id'   => $platformId,
+                'platform_name' => 'TestPlatform',
+                'content'       => str_repeat('字', 100),
+            ]],
+        ], JSON_UNESCAPED_UNICODE),
+        'create_user' => $user->id,
+        'created_at'  => $logTs,
+        'updated_at'  => $logTs,
+        'deleted_at'  => 0,
+    ]);
+
+    $token = auth('api')->login($user);
+    $response = $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->getJson('/api/dashboard/stats?view=overview&range=all');
+
+    $response->assertOk()->assertJsonPath('code', 0);
+
+    $hourDist = $response->json('data.metrics.hour_dist');
+    $weekDist = $response->json('data.metrics.week_dist');
+
+    expect($hourDist)->toBeArray()->toHaveCount(24)
+        ->and($hourDist[10])->toEqual(100)
+        ->and($weekDist)->toBeArray()->toHaveCount(7);
+
+    $todayDow = (int) Carbon::today('Asia/Shanghai')->dayOfWeekIso - 1;
+    expect($weekDist[$todayDow])->toEqual(100);
+});
+
+it('overview 包含 platform dist 和 recent logs', function () {
+    $user = dashboardCreateUser();
+    dashboardAssignSuperRole($user);
+
+    $platformId = DB::table('work_platforms')->insertGetId([
+        'name'       => 'BlogPlatform',
+        'status'     => 1,
+        'created_at' => time(),
+        'updated_at' => time(),
+        'deleted_at' => 0,
+    ]);
+
+    DB::table('work_daily_logs')->insert([
+        'platform_id' => $platformId,
+        'log_date'    => now()->toDateString(),
+        'content'     => json_encode([
+            'platforms' => [[
+                'platform_id'   => $platformId,
+                'platform_name' => 'BlogPlatform',
+                'content'       => '今天写了一些内容',
+            ]],
+        ], JSON_UNESCAPED_UNICODE),
+        'create_user' => $user->id,
+        'created_at'  => time(),
+        'updated_at'  => time(),
+        'deleted_at'  => 0,
+    ]);
+
+    $token = auth('api')->login($user);
+    $response = $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->getJson('/api/dashboard/stats?view=overview&range=all');
+
+    $response->assertOk()->assertJsonPath('code', 0);
+
+    $dist = $response->json('data.platform_dist');
+    expect($dist)->toBeArray()->not->toBeEmpty()
+        ->and($dist[0]['name'])->toEqual('BlogPlatform')
+        ->and($dist[0])->toHaveKeys(['words', 'pct'])
+        ->and($dist[0]['pct'])->toEqual(100.0);
+
+    $logs = $response->json('data.recent_logs');
+    expect($logs)->toBeArray()->not->toBeEmpty()
+        ->and($logs[0])->toHaveKeys(['log_date', 'content']);
+});
+
+/**
+ * 创建仪表盘测试表结构。
+ *
+ * @return void
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/5/26
+ */
+function dashboardCreateSchema(): void
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
+    Schema::create('users', function (Blueprint $table) {
+        $table->id();
+        $table->string('username')->nullable();
+        $table->string('email')->nullable()->unique();
+        $table->string('phone')->nullable()->unique();
+        $table->string('openid')->nullable()->unique();
+        $table->string('unionid')->nullable()->unique();
+        $table->string('password')->nullable();
+        $table->timestamp('email_verified_at')->nullable();
+        $table->integer('status')->default(0);
+        $table->rememberToken();
+        $table->unsignedInteger('created_at')->default(0);
+        $table->integer('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
 
-        Config::set('database.default', 'sqlite');
-        Config::set('database.connections.sqlite.database', ':memory:');
-        DB::purge('sqlite');
-        DB::setDefaultConnection('sqlite');
+    Schema::create('roles', function (Blueprint $table) {
+        $table->id();
+        $table->string('name')->nullable();
+        $table->string('code')->nullable();
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
 
-        Schema::dropAllTables();
-        $this->createDashboardSchema();
-    }
+    Schema::create('user_role', function (Blueprint $table) {
+        $table->unsignedBigInteger('user_id')->default(0);
+        $table->unsignedBigInteger('role_id')->default(0);
+    });
 
-    public function test_未登录请求统计接口返回_401(): void
-    {
-        $response = $this->getJson('/api/dashboard/stats');
+    Schema::create('work_platforms', function (Blueprint $table) {
+        $table->id();
+        $table->string('name', 50)->index();
+        $table->boolean('status')->default(1);
+        $table->smallInteger('sort')->default(0);
+        $table->unsignedInteger('create_user')->default(0);
+        $table->unsignedInteger('created_at')->default(0);
+        $table->unsignedInteger('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
 
-        $response
-            ->assertStatus(200)
-            ->assertJsonPath('code', 401);
-    }
+    Schema::create('work_daily_logs', function (Blueprint $table) {
+        $table->id();
+        $table->unsignedBigInteger('platform_id')->default(0);
+        $table->date('log_date');
+        $table->text('content');
+        $table->unsignedInteger('create_user')->default(0);
+        $table->unsignedInteger('created_at')->default(0);
+        $table->unsignedInteger('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
 
-    public function test_非法_view_or_range_返回_422(): void
-    {
-        $token = $this->createDashboardToken();
+    Schema::create('work_daily_tags', function (Blueprint $table) {
+        $table->id();
+        $table->string('name', 50);
+        $table->unsignedInteger('create_user')->default(0);
+        $table->unsignedInteger('created_at')->default(0);
+        $table->unsignedInteger('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
 
-        $viewResp = $this
-            ->withHeader('Authorization', "Bearer {$token}")
-            ->getJson('/api/dashboard/stats?view=bad');
-        $viewResp
-            ->assertStatus(200)
-            ->assertJsonPath('code', 422);
+    Schema::create('work_daily_log_tag', function (Blueprint $table) {
+        $table->unsignedBigInteger('work_daily_log_id')->default(0);
+        $table->unsignedBigInteger('work_daily_tag_id')->default(0);
+    });
 
-        $rangeResp = $this
-            ->withHeader('Authorization', "Bearer {$token}")
-            ->getJson('/api/dashboard/stats?range=bad');
-        $rangeResp
-            ->assertStatus(200)
-            ->assertJsonPath('code', 422);
-    }
+    Schema::create('work_docs', function (Blueprint $table) {
+        $table->id();
+        $table->unsignedBigInteger('category_id')->default(0);
+        $table->string('title', 255);
+        $table->longText('content');
+        $table->string('template_type', 50)->default('custom');
+        $table->text('tags')->nullable();
+        $table->unsignedTinyInteger('status')->default(1);
+        $table->unsignedTinyInteger('priority')->default(0);
+        $table->string('source', 255)->nullable();
+        $table->unsignedTinyInteger('is_pin')->default(0);
+        $table->unsignedInteger('create_user')->default(0);
+        $table->unsignedInteger('created_at')->default(0);
+        $table->unsignedInteger('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+}
 
-    public function test_空数据用户返回空指标结构_并带_cache_hit(): void
-    {
-        $token = $this->createDashboardToken();
+/**
+ * 创建带超级管理员角色的登录令牌。
+ *
+ * @return string
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/5/26
+ */
+function dashboardCreateToken(): string
+{
+    $user = dashboardCreateUser();
+    dashboardAssignSuperRole($user);
 
-        $first = $this
-            ->withHeader('Authorization', "Bearer {$token}")
-            ->getJson('/api/dashboard/stats');
+    return auth('api')->login($user);
+}
 
-        $first
-            ->assertOk()
-            ->assertJsonPath('code', 0)
-            ->assertJsonPath('data.view', 'overview')
-            ->assertJsonPath('data.metrics.total_words.value', 0)
-            ->assertJsonPath('data.metrics.current_streak.value', 0)
-            ->assertJsonPath('data.metrics.favorite_platform', null)
-            ->assertJsonPath('data.cache_hit', false);
+/**
+ * 创建仪表盘测试用户。
+ *
+ * @return User
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/5/26
+ */
+function dashboardCreateUser(): User
+{
+    static $counter = 0;
+    $counter++;
 
-        $second = $this
-            ->withHeader('Authorization', "Bearer {$token}")
-            ->getJson('/api/dashboard/stats');
+    return User::query()->create([
+        'username' => 'dashboard_user_' . $counter,
+        'email' => "dashboard{$counter}@example.com",
+        'phone' => '1380000' . str_pad((string) $counter, 4, '0', STR_PAD_LEFT),
+        'password' => bcrypt('password'),
+        'status' => 1,
+    ]);
+}
 
-        $second
-            ->assertOk()
-            ->assertJsonPath('code', 0)
-            ->assertJsonPath('data.cache_hit', true);
-    }
+/**
+ * 给用户分配超级管理员角色。
+ *
+ * @param User $user
+ * @return void
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/5/26
+ */
+function dashboardAssignSuperRole(User $user): void
+{
+    $roleId = DB::table('roles')->insertGetId([
+        'name' => '超级管理员',
+        'code' => 'super',
+        'deleted_at' => 0,
+    ]);
 
-    public function test_今天没写但昨天有日志时_current_streak_为_0(): void
-    {
-        $user = $this->createDashboardUser();
-        $this->assignSuperRole($user);
-
-        $platformId = DB::table('work_platforms')->insertGetId([
-            'name' => 'Alpha',
-            'status' => 1,
-            'created_at' => time(),
-            'updated_at' => time(),
-            'deleted_at' => 0,
-        ]);
-
-        $yesterday = Carbon::today('Asia/Shanghai')->subDay();
-        DB::table('work_daily_logs')->insert([
-            'platform_id' => $platformId,
-            'log_date' => $yesterday->toDateString(),
-            'content' => json_encode([
-                'platforms' => [[
-                    'platform_id' => $platformId,
-                    'platform_name' => 'Alpha',
-                    'content' => '昨天产出了一些内容',
-                ]],
-            ], JSON_UNESCAPED_UNICODE),
-            'create_user' => $user->id,
-            'created_at' => $yesterday->copy()->setHour(10)->timestamp,
-            'updated_at' => $yesterday->copy()->setHour(10)->timestamp,
-            'deleted_at' => 0,
-        ]);
-
-        $token = auth('api')->login($user);
-        $response = $this
-            ->withHeader('Authorization', "Bearer {$token}")
-            ->getJson('/api/dashboard/stats?range=7d');
-
-        $response
-            ->assertOk()
-            ->assertJsonPath('code', 0)
-            ->assertJsonPath('data.metrics.current_streak.value', 0)
-            ->assertJsonPath('data.metrics.current_streak.hint', '今天还没写呢');
-    }
-
-    public function test_platform_view_returns_rank_and_matrix(): void
-    {
-        $user = $this->createDashboardUser();
-        $this->assignSuperRole($user);
-
-        $platformId = DB::table('work_platforms')->insertGetId([
-            'name' => 'Gamma',
-            'status' => 1,
-            'created_at' => time(),
-            'updated_at' => time(),
-            'deleted_at' => 0,
-        ]);
-
-        DB::table('work_daily_logs')->insert([
-            'platform_id' => $platformId,
-            'log_date' => now()->toDateString(),
-            'content' => json_encode([
-                'platforms' => [[
-                    'platform_id' => $platformId,
-                    'platform_name' => 'Gamma',
-                    'content' => '平台月度矩阵统计',
-                ]],
-            ], JSON_UNESCAPED_UNICODE),
-            'create_user' => $user->id,
-            'created_at' => Carbon::now('Asia/Shanghai')->setHour(10)->timestamp,
-            'updated_at' => Carbon::now('Asia/Shanghai')->setHour(10)->timestamp,
-            'deleted_at' => 0,
-        ]);
-
-        $token = auth('api')->login($user);
-        $response = $this
-            ->withHeader('Authorization', "Bearer {$token}")
-            ->getJson('/api/dashboard/stats?view=platform&range=30d');
-
-        $response
-            ->assertOk()
-            ->assertJsonPath('code', 0)
-            ->assertJsonPath('data.view', 'platform')
-            ->assertJsonPath('data.rank.0.name', 'Gamma')
-            ->assertJsonPath('data.matrix.rows.0.name', 'Gamma');
-
-        $this->assertCount(12, $response->json('data.matrix.months'));
-        $this->assertCount(12, $response->json('data.matrix.rows.0.cells'));
-        $this->assertIsInt($response->json('data.matrix.rows.0.cells.0'));
-    }
-
-    /**
-     * 创建仪表盘测试表结构。
-     *
-     * @return void
-     * @author zhouxufeng <zxf@netsun.com>
-     * @date 2026/5/26
-     */
-    private function createDashboardSchema(): void
-    {
-        Schema::create('users', function (Blueprint $table) {
-            $table->id();
-            $table->string('username')->nullable();
-            $table->string('email')->nullable()->unique();
-            $table->string('phone')->nullable()->unique();
-            $table->string('openid')->nullable()->unique();
-            $table->string('unionid')->nullable()->unique();
-            $table->string('password')->nullable();
-            $table->timestamp('email_verified_at')->nullable();
-            $table->integer('status')->default(0);
-            $table->rememberToken();
-            $table->unsignedInteger('created_at')->default(0);
-            $table->integer('update_user')->default(0);
-            $table->unsignedInteger('updated_at')->default(0);
-            $table->unsignedInteger('deleted_at')->default(0);
-        });
-
-        Schema::create('roles', function (Blueprint $table) {
-            $table->id();
-            $table->string('name')->nullable();
-            $table->string('code')->nullable();
-            $table->unsignedInteger('deleted_at')->default(0);
-        });
-
-        Schema::create('user_role', function (Blueprint $table) {
-            $table->unsignedBigInteger('user_id')->default(0);
-            $table->unsignedBigInteger('role_id')->default(0);
-        });
-
-        Schema::create('work_platforms', function (Blueprint $table) {
-            $table->id();
-            $table->string('name', 50)->index();
-            $table->boolean('status')->default(1);
-            $table->smallInteger('sort')->default(0);
-            $table->unsignedInteger('create_user')->default(0);
-            $table->unsignedInteger('created_at')->default(0);
-            $table->unsignedInteger('update_user')->default(0);
-            $table->unsignedInteger('updated_at')->default(0);
-            $table->unsignedInteger('deleted_at')->default(0);
-        });
-
-        Schema::create('work_daily_logs', function (Blueprint $table) {
-            $table->id();
-            $table->unsignedBigInteger('platform_id')->default(0);
-            $table->date('log_date');
-            $table->text('content');
-            $table->unsignedInteger('create_user')->default(0);
-            $table->unsignedInteger('created_at')->default(0);
-            $table->unsignedInteger('update_user')->default(0);
-            $table->unsignedInteger('updated_at')->default(0);
-            $table->unsignedInteger('deleted_at')->default(0);
-        });
-
-        Schema::create('work_daily_tags', function (Blueprint $table) {
-            $table->id();
-            $table->string('name', 50);
-            $table->unsignedInteger('create_user')->default(0);
-            $table->unsignedInteger('created_at')->default(0);
-            $table->unsignedInteger('update_user')->default(0);
-            $table->unsignedInteger('updated_at')->default(0);
-            $table->unsignedInteger('deleted_at')->default(0);
-        });
-
-        Schema::create('work_daily_log_tag', function (Blueprint $table) {
-            $table->unsignedBigInteger('work_daily_log_id')->default(0);
-            $table->unsignedBigInteger('work_daily_tag_id')->default(0);
-        });
-
-        Schema::create('work_docs', function (Blueprint $table) {
-            $table->id();
-            $table->unsignedBigInteger('category_id')->default(0);
-            $table->string('title', 255);
-            $table->longText('content');
-            $table->string('template_type', 50)->default('custom');
-            $table->text('tags')->nullable();
-            $table->unsignedTinyInteger('status')->default(1);
-            $table->unsignedTinyInteger('priority')->default(0);
-            $table->string('source', 255)->nullable();
-            $table->unsignedTinyInteger('is_pin')->default(0);
-            $table->unsignedInteger('create_user')->default(0);
-            $table->unsignedInteger('created_at')->default(0);
-            $table->unsignedInteger('update_user')->default(0);
-            $table->unsignedInteger('updated_at')->default(0);
-            $table->unsignedInteger('deleted_at')->default(0);
-        });
-    }
-
-    private function createDashboardToken(): string
-    {
-        $user = $this->createDashboardUser();
-        $this->assignSuperRole($user);
-
-        return auth('api')->login($user);
-    }
-
-    private function createDashboardUser(): User
-    {
-        static $counter = 0;
-        $counter++;
-
-        return User::query()->create([
-            'username' => 'dashboard_user_' . $counter,
-            'email' => "dashboard{$counter}@example.com",
-            'phone' => '1380000' . str_pad((string) $counter, 4, '0', STR_PAD_LEFT),
-            'password' => bcrypt('password'),
-            'status' => 1,
-        ]);
-    }
-
-    private function assignSuperRole(User $user): void
-    {
-        $roleId = DB::table('roles')->insertGetId([
-            'name' => '超级管理员',
-            'code' => 'super',
-            'deleted_at' => 0,
-        ]);
-
-        DB::table('user_role')->insert([
-            'user_id' => $user->id,
-            'role_id' => $roleId,
-        ]);
-    }
-
-    public function test_overview_包含_hour_dist_和_week_dist(): void
-    {
-        $user = $this->createDashboardUser();
-        $this->assignSuperRole($user);
-
-        $platformId = DB::table('work_platforms')->insertGetId([
-            'name'       => 'TestPlatform',
-            'status'     => 1,
-            'created_at' => time(),
-            'updated_at' => time(),
-            'deleted_at' => 0,
-        ]);
-
-        // 在 10:00 (hour=10 CST) 写了一条日志
-        $logTs = Carbon::today('Asia/Shanghai')->setHour(10)->timestamp;
-        DB::table('work_daily_logs')->insert([
-            'platform_id' => $platformId,
-            'log_date'    => now()->toDateString(),
-            'content'     => json_encode([
-                'platforms' => [[
-                    'platform_id'   => $platformId,
-                    'platform_name' => 'TestPlatform',
-                    'content'       => str_repeat('字', 100),
-                ]],
-            ], JSON_UNESCAPED_UNICODE),
-            'create_user' => $user->id,
-            'created_at'  => $logTs,
-            'updated_at'  => $logTs,
-            'deleted_at'  => 0,
-        ]);
-
-        $token = auth('api')->login($user);
-        $response = $this
-            ->withHeader('Authorization', "Bearer {$token}")
-            ->getJson('/api/dashboard/stats?view=overview&range=all');
-
-        $response->assertOk()->assertJsonPath('code', 0);
-
-        $hourDist = $response->json('data.metrics.hour_dist');
-        $weekDist = $response->json('data.metrics.week_dist');
-
-        $this->assertIsArray($hourDist);
-        $this->assertCount(24, $hourDist);
-        $this->assertEquals(100, $hourDist[10]);
-
-        $this->assertIsArray($weekDist);
-        $this->assertCount(7, $weekDist);
-        $todayDow = (int) Carbon::today('Asia/Shanghai')->dayOfWeekIso - 1;
-        $this->assertEquals(100, $weekDist[$todayDow]);
-    }
-
-    public function test_overview_包含_platform_dist_和_recent_logs(): void
-    {
-        $user = $this->createDashboardUser();
-        $this->assignSuperRole($user);
-
-        $platformId = DB::table('work_platforms')->insertGetId([
-            'name'       => 'BlogPlatform',
-            'status'     => 1,
-            'created_at' => time(),
-            'updated_at' => time(),
-            'deleted_at' => 0,
-        ]);
-
-        DB::table('work_daily_logs')->insert([
-            'platform_id' => $platformId,
-            'log_date'    => now()->toDateString(),
-            'content'     => json_encode([
-                'platforms' => [[
-                    'platform_id'   => $platformId,
-                    'platform_name' => 'BlogPlatform',
-                    'content'       => '今天写了一些内容',
-                ]],
-            ], JSON_UNESCAPED_UNICODE),
-            'create_user' => $user->id,
-            'created_at'  => time(),
-            'updated_at'  => time(),
-            'deleted_at'  => 0,
-        ]);
-
-        $token = auth('api')->login($user);
-        $response = $this
-            ->withHeader('Authorization', "Bearer {$token}")
-            ->getJson('/api/dashboard/stats?view=overview&range=all');
-
-        $response->assertOk()->assertJsonPath('code', 0);
-
-        $dist = $response->json('data.platform_dist');
-        $this->assertIsArray($dist);
-        $this->assertNotEmpty($dist);
-        $this->assertEquals('BlogPlatform', $dist[0]['name']);
-        $this->assertArrayHasKey('words', $dist[0]);
-        $this->assertArrayHasKey('pct', $dist[0]);
-        $this->assertEquals(100.0, $dist[0]['pct']);
-
-        $logs = $response->json('data.recent_logs');
-        $this->assertIsArray($logs);
-        $this->assertNotEmpty($logs);
-        $this->assertArrayHasKey('log_date', $logs[0]);
-        $this->assertArrayHasKey('content', $logs[0]);
-    }
+    DB::table('user_role')->insert([
+        'user_id' => $user->id,
+        'role_id' => $roleId,
+    ]);
 }

--- a/tests/Unit/Dashboard/StatsAggregatorTest.php
+++ b/tests/Unit/Dashboard/StatsAggregatorTest.php
@@ -1,119 +1,138 @@
 <?php
 
-namespace Tests\Unit\Dashboard;
-
 use App\Models\Admin\WorkDailyLog;
 use App\Services\Api\Admin\Dashboard\StatsAggregator;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
-use ReflectionMethod;
 use Tests\TestCase;
 
-class StatsAggregatorTest extends TestCase
+uses(TestCase::class);
+
+it('工作日今天和昨天都写时当前连续为 2', function () {
+    // 周一、周二都写，今天周二
+    [$currentStreak, $longestStreak] = statsInvokeStreaks(['2026-06-01', '2026-06-02'], '2026-06-02');
+
+    expect($currentStreak)->toBe(2)
+        ->and($longestStreak)->toBe(2);
+});
+
+it('工作日今天还没写时当前连续归零催写', function () {
+    // 写了周一，今天周二还没写 -> 当前连续归零（方案 A 催写语义）
+    [$currentStreak] = statsInvokeStreaks(['2026-06-01'], '2026-06-02');
+
+    expect($currentStreak)->toBe(0);
+});
+
+it('周末时上一个工作日写过则连续不断签', function () {
+    // 今天周六，上周五写过 -> 连续保留为 1，不因周末归零
+    [$currentStreak] = statsInvokeStreaks(['2026-05-29'], '2026-05-30');
+
+    expect($currentStreak)->toBe(1);
+});
+
+it('跨周末连续工作日的当前与最长均为 4', function () {
+    // 周四、周五、（周末休息）、周一、周二，今天周二
+    [$currentStreak, $longestStreak, $range] = statsInvokeStreaks(
+        ['2026-05-28', '2026-05-29', '2026-06-01', '2026-06-02'],
+        '2026-06-02'
+    );
+
+    expect($currentStreak)->toBe(4)
+        ->and($longestStreak)->toBe(4)
+        ->and($range['start'])->toBe('2026-05-28')
+        ->and($range['end'])->toBe('2026-06-02');
+});
+
+it('周五写过周一漏写则周二当前连续归零', function () {
+    // 写了周五，周一漏写，今天周二 -> 断签归零
+    [$currentStreak] = statsInvokeStreaks(['2026-05-29'], '2026-06-02');
+
+    expect($currentStreak)->toBe(0);
+});
+
+it('只在周末写不形成连续', function () {
+    // 仅周六、周日写，工作日没写 -> 当前与最长都为 0（周末中性跳过）
+    [$currentStreak, $longestStreak] = statsInvokeStreaks(['2026-05-30', '2026-05-31'], '2026-06-01');
+
+    expect($currentStreak)->toBe(0)
+        ->and($longestStreak)->toBe(0);
+});
+
+it('跨月连续工作日能正确计算', function () {
+    // 周四(4/30)、周五(5/1)、（周末）、周一(5/4)、周二(5/5)
+    [$currentStreak, $longestStreak, $range] = statsInvokeStreaks(
+        ['2026-04-30', '2026-05-01', '2026-05-04', '2026-05-05'],
+        '2026-05-05'
+    );
+
+    expect($currentStreak)->toBe(4)
+        ->and($longestStreak)->toBe(4)
+        ->and($range['start'])->toBe('2026-04-30')
+        ->and($range['end'])->toBe('2026-05-05');
+});
+
+it('偏好平台空数据返回 null', function () {
+    $method = new ReflectionMethod(StatsAggregator::class, 'resolveFavoritePlatform');
+    $method->setAccessible(true);
+
+    expect($method->invoke(new StatsAggregator(), []))->toBeNull();
+});
+
+it('高产时段深夜映射为 night', function () {
+    $logs = new Collection([
+        statsMakeLog('2026-05-10', 2, '夜间输出'),
+    ]);
+    $method = new ReflectionMethod(StatsAggregator::class, 'calculatePeakHour');
+    $method->setAccessible(true);
+
+    expect($method->invoke(new StatsAggregator(), $logs)['period'])->toBe('night');
+});
+
+/**
+ * 以指定的活跃日期与基准日调用私有 calculateStreaks。
+ *
+ * @param array $dates
+ * @param string $endDate
+ * @return array
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/6/1
+ */
+function statsInvokeStreaks(array $dates, string $endDate): array
 {
-    public function test_streak_昨天写过今天还没写_仍算连续(): void
-    {
-        $service = new StatsAggregator();
+    $method = new ReflectionMethod(StatsAggregator::class, 'calculateStreaks');
+    $method->setAccessible(true);
 
-        $method = new ReflectionMethod($service, 'calculateStreaks');
-        $method->setAccessible(true);
-        $today = Carbon::today('Asia/Shanghai')->toDateString();
-        $yesterday = Carbon::today('Asia/Shanghai')->subDay()->toDateString();
+    return $method->invoke(new StatsAggregator(), $dates, $endDate);
+}
 
-        [$currentStreak] = $method->invoke($service, [$yesterday], $today);
-
-        $this->assertSame(1, $currentStreak);
-    }
-
-    public function test_streak_连续两天写到昨天_当前连续为_2(): void
-    {
-        $service = new StatsAggregator();
-
-        $method = new ReflectionMethod($service, 'calculateStreaks');
-        $method->setAccessible(true);
-        $today = Carbon::today('Asia/Shanghai');
-        $yesterday = $today->copy()->subDay()->toDateString();
-        $dayBefore = $today->copy()->subDays(2)->toDateString();
-
-        [$currentStreak] = $method->invoke($service, [$dayBefore, $yesterday], $today->toDateString());
-
-        $this->assertSame(2, $currentStreak);
-    }
-
-    public function test_streak_最后写作早于昨天_当前连续归零(): void
-    {
-        $service = new StatsAggregator();
-
-        $method = new ReflectionMethod($service, 'calculateStreaks');
-        $method->setAccessible(true);
-        $today = Carbon::today('Asia/Shanghai');
-        $twoDaysAgo = $today->copy()->subDays(2)->toDateString();
-        $threeDaysAgo = $today->copy()->subDays(3)->toDateString();
-
-        [$currentStreak] = $method->invoke($service, [$threeDaysAgo, $twoDaysAgo], $today->toDateString());
-
-        $this->assertSame(0, $currentStreak);
-    }
-
-    public function test_streak_跨月连续能正确计算(): void
-    {
-        $service = new StatsAggregator();
-        $method = new ReflectionMethod($service, 'calculateStreaks');
-        $method->setAccessible(true);
-
-        $dates = ['2026-04-29', '2026-04-30', '2026-05-01', '2026-05-02'];
-        [$currentStreak, $longestStreak, $range] = $method->invoke($service, $dates, '2026-05-02');
-
-        $this->assertSame(4, $currentStreak);
-        $this->assertSame(4, $longestStreak);
-        $this->assertSame('2026-04-29', $range['start']);
-        $this->assertSame('2026-05-02', $range['end']);
-    }
-
-    public function test_favorite_platform_空数据返回_null(): void
-    {
-        $service = new StatsAggregator();
-        $method = new ReflectionMethod($service, 'resolveFavoritePlatform');
-        $method->setAccessible(true);
-
-        $result = $method->invoke($service, []);
-
-        $this->assertNull($result);
-    }
-
-    public function test_peak_hour_period_深夜映射为_night(): void
-    {
-        $service = new StatsAggregator();
-        $logs = new Collection([
-            $this->makeLog('2026-05-10', 2, '夜间输出'),
-        ]);
-        $method = new ReflectionMethod($service, 'calculatePeakHour');
-        $method->setAccessible(true);
-
-        $peak = $method->invoke($service, $logs);
-
-        $this->assertSame('night', $peak['period']);
-    }
-
-    private function makeLog(string $date, int $hour, string $content): WorkDailyLog
-    {
-        $timestamp = Carbon::parse($date, 'Asia/Shanghai')->setHour($hour)->timestamp;
-        $payload = [
-            'platforms' => [[
-                'platform_id' => 1,
-                'platform_name' => 'Alpha',
-                'content' => $content,
-            ]],
-        ];
-
-        $log = new WorkDailyLog();
-        $log->setRawAttributes([
+/**
+ * 构造一条用于统计的工作日志模型。
+ *
+ * @param string $date
+ * @param int $hour
+ * @param string $content
+ * @return WorkDailyLog
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/6/1
+ */
+function statsMakeLog(string $date, int $hour, string $content): WorkDailyLog
+{
+    $timestamp = Carbon::parse($date, 'Asia/Shanghai')->setHour($hour)->timestamp;
+    $payload = [
+        'platforms' => [[
             'platform_id' => 1,
-            'log_date' => $date,
-            'content' => json_encode($payload, JSON_UNESCAPED_UNICODE),
-            'created_at' => $timestamp,
-        ], true);
+            'platform_name' => 'Alpha',
+            'content' => $content,
+        ]],
+    ];
 
-        return $log;
-    }
+    $log = new WorkDailyLog();
+    $log->setRawAttributes([
+        'platform_id' => 1,
+        'log_date' => $date,
+        'content' => json_encode($payload, JSON_UNESCAPED_UNICODE),
+        'created_at' => $timestamp,
+    ], true);
+
+    return $log;
 }


### PR DESCRIPTION
## 背景
工作台「连续打卡/连续天数」原按自然日统计，周末不写就断签、当前连续归零，与「周末休息」的实际节奏不符。

## 改动（仅后端，前端纯展示后端值无需改）
按工作日（周一~周五）口径重写 `StatsAggregator::calculateStreaks`：
- 周末（六、日）中性跳过：不计入连续、也不打断；相邻判定改用「下一个工作日」，周五↔周一跨周末不断。
- `current_streak` 与 `longest_streak` 口径一致。
- 方案 A：工作日当天未写仍显示 `0` +「今天还没写呢」催写；**周末**保留上一个工作日的连续，不归零。

## 测试
- 单元 + Feature 测试统一改为 **Pest** 格式（与 `ServerPathControllerTest`/`TodoItemControllerTest` 一致）。
- 新增覆盖：跨周末连续、周末不断签、工作日未写归零、漏写工作日断签、只周末写不计、跨月连续。
- 修复历史隐患：依赖「今天」的 Feature 用例改用 `Carbon::setTestNow()` 钉死固定工作日，消除按工作日口径下的随运行日漂移。
- 远端 `./vendor/bin/sail pest` 验证：**16 passed (65 assertions)**。

## 文档
`docs/standards/backend-controller-style.md` 新增「测试格式（Pest）」小节，沉淀本次约定。
