### PR TITLE
feat(work-daily): 报表导出支持本机 Claude CLI 桥

### DIFF
--- a/app/Http/Controllers/Api/Admin/WorkDailyLogController.php
+++ b/app/Http/Controllers/Api/Admin/WorkDailyLogController.php
@@ -644,6 +644,10 @@ class WorkDailyLogController extends Controller
             return $this->callLocalGemini($prompt, $targetModel);
         }
 
+        if ($this->isLocalClaudeModel($targetModel)) {
+            return $this->callLocalClaude($prompt, $targetModel);
+        }
+
         return $this->callOpenClaw($prompt, $targetModel);
     }
 
@@ -792,6 +796,45 @@ class WorkDailyLogController extends Controller
         $content = $response->json('choices.0.message.content');
         if (!is_string($content) || trim($content) === '') {
             throw new \RuntimeException('Local Gemini summary returned empty content');
+        }
+
+        return $content;
+    }
+
+    private function callLocalClaude(string $prompt, string $model): string
+    {
+        $baseUrl = $this->resolveLocalClaudeBridgeUrl();
+        if (!$baseUrl) {
+            throw new \RuntimeException('LOCAL_CLAUDE_BRIDGE_URL 未配置');
+        }
+
+        $headers = [];
+        $token = config('services.local_claude.bridge_token');
+        if (is_string($token) && trim($token) !== '') {
+            $headers['Authorization'] = 'Bearer ' . trim($token);
+        }
+
+        try {
+            $response = Http::withHeaders($headers)
+                ->timeout(240)
+                ->post($baseUrl . '/v1/chat/completions', [
+                    'model' => $model,
+                    'messages' => [
+                        ['role' => 'system', 'content' => '你是一个擅长按平台归纳工作日志的助手，输出中文 Markdown。'],
+                        ['role' => 'user', 'content' => $prompt],
+                    ],
+                ]);
+        } catch (\Illuminate\Http\Client\ConnectionException $e) {
+            throw new \RuntimeException($this->bridgeUnreachableMessage('Claude'), 0, $e);
+        }
+
+        if (!$response->ok()) {
+            throw new \RuntimeException('Local Claude summary failed: ' . $response->status() . ' ' . $response->body());
+        }
+
+        $content = $response->json('choices.0.message.content');
+        if (!is_string($content) || trim($content) === '') {
+            throw new \RuntimeException('Local Claude summary returned empty content');
         }
 
         return $content;
@@ -1040,6 +1083,7 @@ class WorkDailyLogController extends Controller
         if (!empty($configuredModels)) {
             $configuredModels = $this->withLocalCodexModel($configuredModels);
             $configuredModels = $this->withLocalGeminiModel($configuredModels);
+            $configuredModels = $this->withLocalClaudeModel($configuredModels);
             if (!in_array($defaultModel, $configuredModels, true)) {
                 array_unshift($configuredModels, $defaultModel);
             }
@@ -1048,7 +1092,7 @@ class WorkDailyLogController extends Controller
 
         $baseUrl = $this->resolveOpenClawGatewayUrl();
         if (!$baseUrl) {
-            return $this->withLocalGeminiModel($this->withLocalCodexModel([$defaultModel]));
+            return $this->withLocalClaudeModel($this->withLocalGeminiModel($this->withLocalCodexModel([$defaultModel])));
         }
 
         $token = env('OPENCLAW_GATEWAY_TOKEN');
@@ -1091,7 +1135,7 @@ class WorkDailyLogController extends Controller
             array_unshift($models, $defaultModel);
         }
 
-        return $this->withLocalGeminiModel($this->withLocalCodexModel($models));
+        return $this->withLocalClaudeModel($this->withLocalGeminiModel($this->withLocalCodexModel($models)));
     }
 
     private function resolveOpenClawGatewayUrl(): ?string
@@ -1106,6 +1150,15 @@ class WorkDailyLogController extends Controller
     private function resolveLocalCodexBridgeUrl(): ?string
     {
         $baseUrl = config('services.local_codex.bridge_url');
+
+        return is_string($baseUrl) && trim($baseUrl) !== ''
+            ? rtrim($baseUrl, '/')
+            : null;
+    }
+
+    private function resolveLocalClaudeBridgeUrl(): ?string
+    {
+        $baseUrl = config('services.local_claude.bridge_url');
 
         return is_string($baseUrl) && trim($baseUrl) !== ''
             ? rtrim($baseUrl, '/')
@@ -1129,6 +1182,11 @@ class WorkDailyLogController extends Controller
     private function isLocalGeminiModel(string $model): bool
     {
         return str_starts_with($model, 'local-gemini/');
+    }
+
+    private function isLocalClaudeModel(string $model): bool
+    {
+        return str_starts_with($model, 'local-claude/');
     }
 
     private function bridgeUnreachableMessage(string $name): string
@@ -1155,6 +1213,17 @@ class WorkDailyLogController extends Controller
         $localModel = config('services.local_gemini.model', 'local-gemini/gemini-cli');
         if (!is_string($localModel) || trim($localModel) === '') {
             $localModel = 'local-gemini/gemini-cli';
+        }
+        $models[] = trim($localModel);
+
+        return array_values(array_unique(array_filter($models)));
+    }
+
+    private function withLocalClaudeModel(array $models): array
+    {
+        $localModel = config('services.local_claude.model', 'local-claude/claude-cli');
+        if (!is_string($localModel) || trim($localModel) === '') {
+            $localModel = 'local-claude/claude-cli';
         }
         $models[] = trim($localModel);
 

--- a/app/Services/Api/Admin/WorkDailyReportService.php
+++ b/app/Services/Api/Admin/WorkDailyReportService.php
@@ -334,6 +334,10 @@ class WorkDailyReportService
             return $this->callLocalGemini($prompt, $targetModel);
         }
 
+        if ($this->isLocalClaudeModel($targetModel)) {
+            return $this->callLocalClaude($prompt, $targetModel);
+        }
+
         return $this->callOpenClaw($prompt, $targetModel);
     }
 
@@ -463,6 +467,45 @@ class WorkDailyReportService
         return $content;
     }
 
+    private function callLocalClaude(string $prompt, string $model): string
+    {
+        $baseUrl = $this->resolveLocalClaudeBridgeUrl();
+        if (!$baseUrl) {
+            throw new \RuntimeException('LOCAL_CLAUDE_BRIDGE_URL 未配置');
+        }
+
+        $headers = [];
+        $token = config('services.local_claude.bridge_token');
+        if (is_string($token) && trim($token) !== '') {
+            $headers['Authorization'] = 'Bearer ' . trim($token);
+        }
+
+        try {
+            $response = Http::withHeaders($headers)
+                ->timeout(240)
+                ->post($baseUrl . '/v1/chat/completions', [
+                    'model' => $model,
+                    'messages' => [
+                        ['role' => 'system', 'content' => '你是一个擅长按平台归纳工作日志的助手，输出中文 Markdown。'],
+                        ['role' => 'user', 'content' => $prompt],
+                    ],
+                ]);
+        } catch (\Illuminate\Http\Client\ConnectionException $e) {
+            throw new \RuntimeException($this->bridgeUnreachableMessage('Claude'), 0, $e);
+        }
+
+        if (!$response->ok()) {
+            throw new \RuntimeException('Local Claude summary failed: ' . $response->status() . ' ' . $this->extractResponseError($response->body()));
+        }
+
+        $content = $response->json('choices.0.message.content');
+        if (!is_string($content) || trim($content) === '') {
+            throw new \RuntimeException('Local Claude summary returned empty content');
+        }
+
+        return $content;
+    }
+
     private function callBailianDirect(string $prompt, string $model): string
     {
         $apiKey = env('OPENCLAW_BAILIAN_API_KEY');
@@ -526,6 +569,15 @@ class WorkDailyReportService
             : null;
     }
 
+    private function resolveLocalClaudeBridgeUrl(): ?string
+    {
+        $baseUrl = config('services.local_claude.bridge_url');
+
+        return is_string($baseUrl) && trim($baseUrl) !== ''
+            ? rtrim($baseUrl, '/')
+            : null;
+    }
+
     private function isLocalCodexModel(string $model): bool
     {
         return str_starts_with($model, 'local-codex/');
@@ -534,6 +586,11 @@ class WorkDailyReportService
     private function isLocalGeminiModel(string $model): bool
     {
         return str_starts_with($model, 'local-gemini/');
+    }
+
+    private function isLocalClaudeModel(string $model): bool
+    {
+        return str_starts_with($model, 'local-claude/');
     }
 
     private function bridgeUnreachableMessage(string $name): string

--- a/config/services.php
+++ b/config/services.php
@@ -55,6 +55,12 @@ return [
         'model' => env('LOCAL_GEMINI_MODEL', 'local-gemini/gemini-cli'),
     ],
 
+    'local_claude' => [
+        'bridge_url' => env('LOCAL_CLAUDE_BRIDGE_URL'),
+        'bridge_token' => env('LOCAL_CLAUDE_BRIDGE_TOKEN'),
+        'model' => env('LOCAL_CLAUDE_MODEL', 'local-claude/claude-cli'),
+    ],
+
     'client_ip_override' => [
         'source' => env('CLIENT_IP_OVERRIDE_SOURCE'),
         'target' => env('CLIENT_IP_OVERRIDE_TARGET'),


### PR DESCRIPTION
## 需求
工作日常报表导出参考 Codex / Gemini 新增 **Claude** 供应商的后端链路（配套前端 blog-ui-vue3 PR #45）。

## 改动
- `WorkDailyReportService.php`：`callReportModel` 增加 `local-claude/` 分支 → `callLocalClaude`（镜像 codex/gemini，打到 `LOCAL_CLAUDE_BRIDGE_URL` 的 `/v1/chat/completions`，桥不通时复用 `bridgeUnreachableMessage('Claude')`）；新增 `resolveLocalClaudeBridgeUrl` / `isLocalClaudeModel`。
- `WorkDailyLogController.php`：同步加一套 `callLocalClaude` / `resolve` / `isLocal` / `withLocalClaudeModel`，并在 `fetchOpenClawModels` 三处列表构建串上 `withLocalClaudeModel`，暴露 `local-claude/claude-cli`。
- `config/services.php`：新增 `local_claude` 块（`LOCAL_CLAUDE_BRIDGE_URL` / `LOCAL_CLAUDE_BRIDGE_TOKEN` / `LOCAL_CLAUDE_MODEL`）。

## 运行前提（部署侧）
远端 `.env` 配 `LOCAL_CLAUDE_BRIDGE_URL` / `LOCAL_CLAUDE_BRIDGE_TOKEN`，并起本机 Claude CLI 桥 + 远端 socat/隧道；未配置时选 Claude 导出会提示「本机 Claude CLI 桥未连通」。

## 验证
- 三文件 `php -l` 无语法错误。
- 已 rsync 远端 + `php artisan config:clear` + `queue:restart`；`/work-daily/report/models` 已返回 `local-claude/claude-cli`。