### PR TITLE
feat: 番茄钟 + 提醒清单后端（阶段一）

### DIFF
--- a/app/Http/Controllers/Api/Admin/PomoSettingController.php
+++ b/app/Http/Controllers/Api/Admin/PomoSettingController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Api\Controller;
+use App\Http\Requests\Api\Admin\PomoSettingRequest;
+use App\Http\Resources\BaseResource;
+use App\Models\Admin\PomoSetting;
+
+class PomoSettingController extends Controller
+{
+    /**
+     * 读取当前用户番茄钟设置，无则返回默认。
+     *
+     * @param PomoSetting $pomoSetting
+     * @return BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/8
+     */
+    public function show(PomoSetting $pomoSetting)
+    {
+        $userId = auth('api')->id();
+
+        $setting = PomoSetting::query()->firstOrNew(['create_user' => $userId]);
+
+        return $this->resource($setting);
+    }
+
+    /**
+     * 保存当前用户番茄钟设置。
+     *
+     * @param PomoSettingRequest $request
+     * @return BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/8
+     */
+    public function save(PomoSettingRequest $request)
+    {
+        $userId = auth('api')->id();
+
+        $setting = PomoSetting::query()->firstOrNew(['create_user' => $userId]);
+
+        $setting->fill($request->getSnakeRequest());
+
+        $setting->edit();
+
+        return $this->resource($setting);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/PomoStatsController.php
+++ b/app/Http/Controllers/Api/Admin/PomoStatsController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Api\Controller;
+use App\Http\Requests\Api\Admin\PomoStatsRequest;
+use App\Models\Admin\PomoSession;
+use App\Models\Admin\PomoTask;
+use Carbon\Carbon;
+
+class PomoStatsController extends Controller
+{
+    /**
+     * 记录一次完成的专注段，并给关联任务番茄数 +1。
+     *
+     * @param PomoStatsRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/8
+     */
+    public function storeSession(PomoStatsRequest $request)
+    {
+        $userId = auth('api')->id();
+        $taskId = (int) ($request->input('task_id') ?? 0);
+
+        $session = new PomoSession();
+        $session->fill([
+            'task_id' => $taskId,
+            'day' => Carbon::now()->format('Y-m-d'),
+            'completed_at' => time(),
+        ]);
+        $session->edit();
+
+        if ($taskId > 0) {
+            $task = PomoTask::query()
+                ->where('create_user', $userId)
+                ->whereKey($taskId)
+                ->first();
+            if ($task) {
+                $task->completed_pomos = $task->completed_pomos + 1;
+                $task->edit();
+            }
+        }
+
+        return response()->json([]);
+    }
+
+    /**
+     * 近 7 天（含今天）每日完成番茄数，缺失日补 0，本地时区口径。
+     *
+     * @return \Illuminate\Http\JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/8
+     */
+    public function week()
+    {
+        $userId = auth('api')->id();
+
+        $start = Carbon::now()->subDays(6)->format('Y-m-d');
+
+        $counts = PomoSession::query()
+            ->where('create_user', $userId)
+            ->where('day', '>=', $start)
+            ->selectRaw('day, COUNT(*) as count')
+            ->groupBy('day')
+            ->pluck('count', 'day');
+
+        $out = [];
+        for ($i = 6; $i >= 0; $i--) {
+            $day = Carbon::now()->subDays($i)->format('Y-m-d');
+            $out[] = ['day' => $day, 'count' => (int) ($counts[$day] ?? 0)];
+        }
+
+        return response()->json(['data' => $out]);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/PomoTaskController.php
+++ b/app/Http/Controllers/Api/Admin/PomoTaskController.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Api\Controller;
+use App\Http\Requests\Api\Admin\PomoTaskRequest;
+use App\Http\Resources\BaseResource;
+use App\Models\Admin\PomoTask;
+use Spatie\QueryBuilder\QueryBuilder;
+
+class PomoTaskController extends Controller
+{
+    /**
+     * 当前用户任务列表 - 分页。
+     *
+     * @param PomoTaskRequest $request
+     * @param PomoTask $pomoTask
+     * @return BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/8
+     */
+    public function index(PomoTaskRequest $request, PomoTask $pomoTask)
+    {
+        $allowedFilters = $request->generateAllowedFilters($pomoTask->getRequestFilters());
+
+        $tasks = QueryBuilder::for($pomoTask)
+            ->where('create_user', auth('api')->id())
+            ->allowedFilters($allowedFilters)
+            ->orderBy('done', 'asc')
+            ->orderBy('sort', 'asc')
+            ->orderBy('id', 'desc')
+            ->paginate($request->perPage());
+
+        return $this->resource($tasks, ['time' => true, 'collection' => true]);
+    }
+
+    /**
+     * 任务详情。
+     *
+     * @param PomoTask $pomoTask
+     * @return BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/8
+     */
+    public function info(PomoTask $pomoTask)
+    {
+        $this->authorizeOwner($pomoTask);
+
+        return $this->resource($pomoTask);
+    }
+
+    /**
+     * 新增任务。
+     *
+     * @param PomoTaskRequest $request
+     * @param PomoTask $pomoTask
+     * @return BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/8
+     */
+    public function add(PomoTaskRequest $request, PomoTask $pomoTask)
+    {
+        $pomoTask->fill($request->getSnakeRequest());
+
+        $pomoTask->edit();
+
+        return $this->resource($pomoTask);
+    }
+
+    /**
+     * 编辑任务。
+     *
+     * @param PomoTask $pomoTask
+     * @param PomoTaskRequest $request
+     * @return BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/8
+     */
+    public function edit(PomoTask $pomoTask, PomoTaskRequest $request)
+    {
+        $this->authorizeOwner($pomoTask);
+
+        $pomoTask->fill($request->getSnakeRequest());
+
+        $pomoTask->edit();
+
+        return $this->resource($pomoTask);
+    }
+
+    /**
+     * 切换完成状态。
+     *
+     * @param PomoTask $pomoTask
+     * @return BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/8
+     */
+    public function toggleDone(PomoTask $pomoTask)
+    {
+        $this->authorizeOwner($pomoTask);
+
+        $pomoTask->done = $pomoTask->done ? 0 : 1;
+
+        $pomoTask->edit();
+
+        return $this->resource($pomoTask);
+    }
+
+    /**
+     * 已完成番茄数 +1。
+     *
+     * @param PomoTask $pomoTask
+     * @return BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/8
+     */
+    public function increment(PomoTask $pomoTask)
+    {
+        $this->authorizeOwner($pomoTask);
+
+        $pomoTask->completed_pomos = $pomoTask->completed_pomos + 1;
+
+        $pomoTask->edit();
+
+        return $this->resource($pomoTask);
+    }
+
+    /**
+     * 删除任务。
+     *
+     * @param PomoTask $pomoTask
+     * @return \Illuminate\Http\JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/8
+     */
+    public function delete(PomoTask $pomoTask)
+    {
+        $this->authorizeOwner($pomoTask);
+
+        $pomoTask->delete();
+
+        return response()->json([]);
+    }
+
+    /**
+     * 批量删除当前用户任务。
+     *
+     * @param PomoTaskRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/8
+     */
+    public function batchDelete(PomoTaskRequest $request)
+    {
+        PomoTask::query()
+            ->where('create_user', auth('api')->id())
+            ->whereIn('id', $request->integerIds())
+            ->delete();
+
+        return response()->json([]);
+    }
+
+    /**
+     * 校验任务归属当前用户（super 角色放行）。
+     *
+     * @param PomoTask $pomoTask
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/8
+     */
+    private function authorizeOwner(PomoTask $pomoTask): void
+    {
+        $user = auth('api')->user();
+
+        $isManager = false;
+        foreach ($user->roles as $role) {
+            if ($role->code === 'super') {
+                $isManager = true;
+            }
+        }
+
+        if (!$isManager && $pomoTask->create_user != $user->id) {
+            abort(403, '无权操作此任务');
+        }
+    }
+}

--- a/app/Http/Requests/Api/Admin/PomoSettingRequest.php
+++ b/app/Http/Requests/Api/Admin/PomoSettingRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Requests\Api\Admin;
+
+use App\Http\Requests\Api\FormRequest;
+
+class PomoSettingRequest extends FormRequest
+{
+    /**
+     * 番茄钟设置接口校验规则。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/8
+     */
+    public function rules(): array
+    {
+        $method = $this->route()->getActionMethod();
+
+        return match ($method) {
+            'save' => [
+                'focus_min' => ['required', 'integer', 'min:1', 'max:600'],
+                'short_break_min' => ['required', 'integer', 'min:1', 'max:600'],
+                'long_break_min' => ['required', 'integer', 'min:1', 'max:600'],
+                'long_break_every' => ['required', 'integer', 'min:1', 'max:99'],
+                'auto_start_next' => ['required', 'boolean'],
+                'sound_on' => ['required', 'boolean'],
+                'white_noise' => ['nullable', 'string', 'in:rain,forest,wave'],
+                'white_noise_volume' => ['required', 'numeric', 'min:0', 'max:1'],
+            ],
+            default => [],
+        };
+    }
+
+    /**
+     * 字段别名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/8
+     */
+    public function attributes(): array
+    {
+        return [
+            'focus_min' => '专注时长',
+            'short_break_min' => '短休时长',
+            'long_break_min' => '长休时长',
+            'long_break_every' => '长休间隔',
+            'auto_start_next' => '自动进入下一阶段',
+            'sound_on' => '提示音',
+            'white_noise' => '白噪音',
+            'white_noise_volume' => '白噪音音量',
+        ];
+    }
+}

--- a/app/Http/Requests/Api/Admin/PomoStatsRequest.php
+++ b/app/Http/Requests/Api/Admin/PomoStatsRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests\Api\Admin;
+
+use App\Http\Requests\Api\FormRequest;
+
+class PomoStatsRequest extends FormRequest
+{
+    /**
+     * 番茄钟统计/完成段接口校验规则。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/8
+     */
+    public function rules(): array
+    {
+        $method = $this->route()->getActionMethod();
+
+        return match ($method) {
+            'storeSession' => [
+                'task_id' => ['nullable', 'integer', 'min:0'],
+            ],
+            default => [],
+        };
+    }
+
+    /**
+     * 字段别名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/8
+     */
+    public function attributes(): array
+    {
+        return [
+            'task_id' => '关联任务',
+        ];
+    }
+}

--- a/app/Http/Requests/Api/Admin/PomoTaskRequest.php
+++ b/app/Http/Requests/Api/Admin/PomoTaskRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Requests\Api\Admin;
+
+use App\Http\Requests\Api\FormRequest;
+
+class PomoTaskRequest extends FormRequest
+{
+    /**
+     * 番茄钟任务接口校验规则。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/8
+     */
+    public function rules(): array
+    {
+        $method = $this->route()->getActionMethod();
+
+        return match ($method) {
+            'index' => array_merge($this->paginationRules(), [
+                'done' => ['nullable', 'boolean'],
+                'filter' => ['nullable', 'array'],
+                'filter.done' => ['nullable', 'boolean'],
+            ]),
+            'add', 'edit' => [
+                'title' => ['required', 'string', 'max:255'],
+                'estimated_pomos' => ['required', 'integer', 'min:1', 'max:99'],
+            ],
+            'batchDelete' => [
+                'id' => ['required'],
+            ],
+            default => [],
+        };
+    }
+
+    /**
+     * 字段别名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/6/8
+     */
+    public function attributes(): array
+    {
+        return array_merge($this->paginationAttributes(), [
+            'title' => '任务标题',
+            'estimated_pomos' => '预估番茄数',
+            'done' => '完成状态',
+            'id' => '记录 ID',
+        ]);
+    }
+}

--- a/app/Models/Admin/PomoSession.php
+++ b/app/Models/Admin/PomoSession.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models\Admin;
+
+use App\Models\BaseModel;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class PomoSession extends BaseModel
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'task_id',
+        'day',
+        'completed_at',
+    ];
+}

--- a/app/Models/Admin/PomoSetting.php
+++ b/app/Models/Admin/PomoSetting.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models\Admin;
+
+use App\Models\BaseModel;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class PomoSetting extends BaseModel
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'focus_min',
+        'short_break_min',
+        'long_break_min',
+        'long_break_every',
+        'auto_start_next',
+        'sound_on',
+        'white_noise',
+        'white_noise_volume',
+    ];
+
+    protected $casts = [
+        'white_noise_volume' => 'float',
+    ];
+
+    protected $attributes = [
+        'focus_min' => 25,
+        'short_break_min' => 5,
+        'long_break_min' => 15,
+        'long_break_every' => 4,
+        'auto_start_next' => 0,
+        'sound_on' => 1,
+        'white_noise' => null,
+        'white_noise_volume' => 0.60,
+    ];
+}

--- a/app/Models/Admin/PomoTask.php
+++ b/app/Models/Admin/PomoTask.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models\Admin;
+
+use App\Models\BaseModel;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class PomoTask extends BaseModel
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title',
+        'estimated_pomos',
+        'completed_pomos',
+        'done',
+        'sort',
+    ];
+
+    protected $requestFilters = [
+        'done' => ['column' => 'done'],
+    ];
+}

--- a/database/migrations/2026_06_08_100000_create_pomo_tasks_table.php
+++ b/database/migrations/2026_06_08_100000_create_pomo_tasks_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pomo_tasks', function (Blueprint $table) {
+            $table->id()->comment('主键ID');
+            $table->string('title', 255)->comment('任务标题');
+            $table->unsignedInteger('estimated_pomos')->default(1)->comment('预估番茄数');
+            $table->unsignedInteger('completed_pomos')->default(0)->comment('已完成番茄数');
+            $table->unsignedTinyInteger('done')->default(0)->comment('是否完成 0否 1是');
+            $table->unsignedInteger('sort')->default(0)->index('index_sort')->comment('排序');
+            $table->unsignedInteger('create_user')->default(0)->index('index_create_user')->comment('所属用户');
+            $table->unsignedInteger('created_at')->default(0)->comment('创建时间');
+            $table->unsignedInteger('update_user')->default(0)->comment('更新人');
+            $table->unsignedInteger('updated_at')->default(0)->comment('更新时间');
+            $table->unsignedInteger('deleted_at')->default(0)->comment('删除时间');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pomo_tasks');
+    }
+};

--- a/database/migrations/2026_06_08_100001_create_pomo_sessions_table.php
+++ b/database/migrations/2026_06_08_100001_create_pomo_sessions_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pomo_sessions', function (Blueprint $table) {
+            $table->id()->comment('主键ID');
+            $table->unsignedBigInteger('task_id')->default(0)->index('index_task_id')->comment('关联任务 0为无');
+            $table->char('day', 10)->index('index_day')->comment('完成日期 YYYY-MM-DD 本地时区');
+            $table->unsignedInteger('completed_at')->default(0)->comment('完成时间戳');
+            $table->unsignedInteger('create_user')->default(0)->index('index_create_user')->comment('所属用户');
+            $table->unsignedInteger('created_at')->default(0)->comment('创建时间');
+            $table->unsignedInteger('update_user')->default(0)->comment('更新人');
+            $table->unsignedInteger('updated_at')->default(0)->comment('更新时间');
+            $table->unsignedInteger('deleted_at')->default(0)->comment('删除时间');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pomo_sessions');
+    }
+};

--- a/database/migrations/2026_06_08_100002_create_pomo_settings_table.php
+++ b/database/migrations/2026_06_08_100002_create_pomo_settings_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pomo_settings', function (Blueprint $table) {
+            $table->id()->comment('主键ID');
+            $table->unsignedInteger('create_user')->default(0)->unique('uniq_create_user')->comment('所属用户');
+            $table->unsignedInteger('focus_min')->default(25)->comment('专注时长(分)');
+            $table->unsignedInteger('short_break_min')->default(5)->comment('短休(分)');
+            $table->unsignedInteger('long_break_min')->default(15)->comment('长休(分)');
+            $table->unsignedInteger('long_break_every')->default(4)->comment('每N个专注后长休');
+            $table->unsignedTinyInteger('auto_start_next')->default(0)->comment('自动进入下一阶段 0否 1是');
+            $table->unsignedTinyInteger('sound_on')->default(1)->comment('提示音 0关 1开');
+            $table->string('white_noise', 50)->nullable()->comment('白噪音类型 rain/forest/wave 或空');
+            $table->decimal('white_noise_volume', 3, 2)->default(0.60)->comment('白噪音音量 0~1');
+            $table->unsignedInteger('update_user')->default(0)->comment('更新人');
+            $table->unsignedInteger('updated_at')->default(0)->comment('更新时间');
+            $table->unsignedInteger('created_at')->default(0)->comment('创建时间');
+            $table->unsignedInteger('deleted_at')->default(0)->comment('删除时间');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pomo_settings');
+    }
+};

--- a/database/migrations/2026_06_08_100003_add_pomo_menu.php
+++ b/database/migrations/2026_06_08_100003_add_pomo_menu.php
@@ -1,0 +1,118 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class AddPomoMenu extends Migration
+{
+    public function up(): void
+    {
+        // 复用已有「个人中心」顶级菜单；不存在则创建
+        $parent = DB::table('menus')
+            ->where('title', '个人中心')
+            ->where('type', 0)
+            ->where('pid', 0)
+            ->first();
+
+        $parentId = $parent
+            ? (int) $parent->id
+            : $this->upsertMenu('/profile-center', [
+                'pid' => 0,
+                'title' => '个人中心',
+                'icon' => 'el-icon-user',
+                'component' => '',
+                'target' => '_self',
+                'permission' => '',
+                'type' => 0,
+                'status' => 1,
+                'hide' => 0,
+                'note' => '',
+                'sort' => 90,
+            ]);
+
+        $pomoId = $this->upsertMenu('/profile-center/pomo', [
+            'pid' => $parentId,
+            'title' => '专注番茄',
+            'icon' => 'el-icon-alarm-clock',
+            'component' => '/pomo/index',
+            'target' => '_self',
+            'permission' => 'pomo:view',
+            'type' => 0,
+            'status' => 1,
+            'hide' => 0,
+            'note' => '番茄钟 + 提醒清单',
+            'sort' => 10,
+        ]);
+
+        $this->grantToAdminRoles([$parentId, $pomoId]);
+    }
+
+    public function down(): void
+    {
+        $ids = DB::table('menus')
+            ->whereIn('path', ['/profile-center/pomo'])
+            ->pluck('id')
+            ->all();
+
+        if (!$ids) {
+            return;
+        }
+
+        DB::table('role_menu')->whereIn('menu_id', $ids)->delete();
+        DB::table('menus')->whereIn('id', $ids)->delete();
+    }
+
+    private function upsertMenu(string $path, array $data): int
+    {
+        $now = time();
+        $existing = DB::table('menus')
+            ->where('path', $path)
+            ->where('type', 0)
+            ->first();
+
+        $payload = array_merge($data, [
+            'path' => $path,
+            'update_user' => 0,
+            'updated_at' => $now,
+            'deleted_at' => 0,
+        ]);
+
+        if ($existing) {
+            DB::table('menus')->where('id', $existing->id)->update($payload);
+            return (int) $existing->id;
+        }
+
+        return (int) DB::table('menus')->insertGetId(array_merge($payload, [
+            'create_user' => 0,
+            'created_at' => $now,
+        ]));
+    }
+
+    private function grantToAdminRoles(array $menuIds): void
+    {
+        $roleIds = DB::table('roles')
+            ->whereIn('code', ['super', 'admin'])
+            ->pluck('id')
+            ->all();
+
+        if (!$roleIds) {
+            return;
+        }
+
+        foreach ($roleIds as $roleId) {
+            foreach ($menuIds as $menuId) {
+                $exists = DB::table('role_menu')
+                    ->where('role_id', $roleId)
+                    ->where('menu_id', $menuId)
+                    ->exists();
+
+                if (!$exists) {
+                    DB::table('role_menu')->insert([
+                        'role_id' => $roleId,
+                        'menu_id' => $menuId,
+                    ]);
+                }
+            }
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,6 +26,10 @@ use App\Http\Controllers\Api\Admin\WorkPlatformController;
 use App\Http\Controllers\Api\Admin\WorkDocController;
 use App\Http\Controllers\Api\Admin\WorkDocCategoryController;
 use App\Http\Controllers\Api\Admin\TodoItemController;
+use App\Http\Controllers\Api\Admin\PomoTaskController;
+use App\Http\Controllers\Api\Admin\PomoSettingController;
+use App\Http\Controllers\Api\Admin\PomoStatsController;
+use App\Models\Admin\PomoTask;
 use App\Http\Controllers\Api\Admin\DashboardController;
 use App\Http\Controllers\Api\Web\ArticlesController;
 use App\Http\Controllers\Api\Web\CategoriesController;
@@ -390,6 +394,27 @@ Route::name('api')->group(function () {
         Route::post('todo/status/{todoItem}', [TodoItemController::class, 'updateStatus'])->name('todo.update-status');
         Route::post('todo/{todoItem}', [TodoItemController::class, 'edit'])->name('todo.edit');
         Route::delete('todo/{todoItem}', [TodoItemController::class, 'delete'])->name('todo.delete');
+
+        /** 番茄钟 + 提醒清单接口开始 */
+        // 番茄钟设置：读取 / 保存
+        Route::get('pomo/setting', [PomoSettingController::class, 'show'])->name('pomo.setting.show');
+        Route::post('pomo/setting', [PomoSettingController::class, 'save'])->name('pomo.setting.save');
+        // 提醒清单任务列表
+        Route::get('pomo/task/index', [PomoTaskController::class, 'index'])->name('pomo.task.index')
+            ->middleware('filter.process:' . PomoTask::class);
+        // 勾选完成 / 番茄数 +1 / 添加 / 批量删除（须排在通配 {pomoTask} 之前）
+        Route::post('pomo/task/toggle-done/{pomoTask}', [PomoTaskController::class, 'toggleDone'])->name('pomo.task.toggle-done');
+        Route::post('pomo/task/increment/{pomoTask}', [PomoTaskController::class, 'increment'])->name('pomo.task.increment');
+        Route::post('pomo/task/add', [PomoTaskController::class, 'add'])->name('pomo.task.add');
+        Route::post('pomo/task/delete', [PomoTaskController::class, 'batchDelete'])->name('pomo.task.batch-delete');
+        // 任务详情 / 编辑 / 删除
+        Route::get('pomo/task/{pomoTask}', [PomoTaskController::class, 'info'])->name('pomo.task.info');
+        Route::post('pomo/task/{pomoTask}', [PomoTaskController::class, 'edit'])->name('pomo.task.edit');
+        Route::delete('pomo/task/{pomoTask}', [PomoTaskController::class, 'delete'])->name('pomo.task.delete');
+        // 完成段记录 / 近 7 天统计
+        Route::post('pomo/session', [PomoStatsController::class, 'storeSession'])->name('pomo.session.store');
+        Route::get('pomo/stats/week', [PomoStatsController::class, 'week'])->name('pomo.stats.week');
+        /** 番茄钟 + 提醒清单接口结束 */
         /** 开发助手接口结束 */
         /** 笔记接口开始 */
         // 文章列表

--- a/tests/Feature/Api/Admin/PomoSettingControllerTest.php
+++ b/tests/Feature/Api/Admin/PomoSettingControllerTest.php
@@ -69,8 +69,8 @@ it('首次读取设置返回默认值', function () {
         ->getJson('/api/pomo/setting')
         ->assertOk()
         ->assertJsonPath('code', 0)
-        ->assertJsonPath('data.focus_min', 25)
-        ->assertJsonPath('data.long_break_every', 4);
+        ->assertJsonPath('data.focusMin', 25)
+        ->assertJsonPath('data.longBreakEvery', 4);
 });
 
 it('保存设置后再次读取返回新值且按用户隔离', function () {
@@ -90,15 +90,15 @@ it('保存设置后再次读取返回新值且按用户隔离', function () {
         ])
         ->assertOk()
         ->assertJsonPath('code', 0)
-        ->assertJsonPath('data.focus_min', 50);
+        ->assertJsonPath('data.focusMin', 50);
 
     expect(PomoSetting::where('create_user', $user->id)->count())->toBe(1);
 
     $this->withHeader('Authorization', "Bearer {$token}")
         ->getJson('/api/pomo/setting')
         ->assertOk()
-        ->assertJsonPath('data.focus_min', 50)
-        ->assertJsonPath('data.white_noise', 'rain');
+        ->assertJsonPath('data.focusMin', 50)
+        ->assertJsonPath('data.whiteNoise', 'rain');
 });
 
 /**

--- a/tests/Feature/Api/Admin/PomoSettingControllerTest.php
+++ b/tests/Feature/Api/Admin/PomoSettingControllerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Models\Admin\PomoSetting;
+use App\Models\User\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    Config::set('database.default', 'sqlite');
+    Config::set('database.connections.sqlite.database', ':memory:');
+    DB::purge('sqlite');
+    DB::setDefaultConnection('sqlite');
+
+    Schema::dropAllTables();
+
+    Schema::create('users', function (Blueprint $table) {
+        $table->id();
+        $table->string('username')->nullable();
+        $table->string('email')->nullable()->unique();
+        $table->string('phone')->nullable()->unique();
+        $table->string('password')->nullable();
+        $table->integer('status')->default(0);
+        $table->rememberToken();
+        $table->unsignedInteger('created_at')->default(0);
+        $table->integer('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+
+    Schema::create('roles', function (Blueprint $table) {
+        $table->id();
+        $table->string('name')->nullable();
+        $table->string('code')->nullable();
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+
+    Schema::create('user_role', function (Blueprint $table) {
+        $table->unsignedBigInteger('user_id')->default(0);
+        $table->unsignedBigInteger('role_id')->default(0);
+    });
+
+    Schema::create('pomo_settings', function (Blueprint $table) {
+        $table->id();
+        $table->unsignedInteger('create_user')->default(0)->unique();
+        $table->unsignedInteger('focus_min')->default(25);
+        $table->unsignedInteger('short_break_min')->default(5);
+        $table->unsignedInteger('long_break_min')->default(15);
+        $table->unsignedInteger('long_break_every')->default(4);
+        $table->unsignedTinyInteger('auto_start_next')->default(0);
+        $table->unsignedTinyInteger('sound_on')->default(1);
+        $table->string('white_noise', 50)->nullable();
+        $table->decimal('white_noise_volume', 3, 2)->default(0.60);
+        $table->unsignedInteger('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('created_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+});
+
+it('首次读取设置返回默认值', function () {
+    $user = pomoSettingLoginUser();
+
+    $this->withHeader('Authorization', 'Bearer ' . auth('api')->login($user))
+        ->getJson('/api/pomo/setting')
+        ->assertOk()
+        ->assertJsonPath('code', 0)
+        ->assertJsonPath('data.focus_min', 25)
+        ->assertJsonPath('data.long_break_every', 4);
+});
+
+it('保存设置后再次读取返回新值且按用户隔离', function () {
+    $user = pomoSettingLoginUser();
+    $token = auth('api')->login($user);
+
+    $this->withHeader('Authorization', "Bearer {$token}")
+        ->postJson('/api/pomo/setting', [
+            'focusMin' => 50,
+            'shortBreakMin' => 10,
+            'longBreakMin' => 20,
+            'longBreakEvery' => 3,
+            'autoStartNext' => true,
+            'soundOn' => false,
+            'whiteNoise' => 'rain',
+            'whiteNoiseVolume' => 0.8,
+        ])
+        ->assertOk()
+        ->assertJsonPath('code', 0)
+        ->assertJsonPath('data.focus_min', 50);
+
+    expect(PomoSetting::where('create_user', $user->id)->count())->toBe(1);
+
+    $this->withHeader('Authorization', "Bearer {$token}")
+        ->getJson('/api/pomo/setting')
+        ->assertOk()
+        ->assertJsonPath('data.focus_min', 50)
+        ->assertJsonPath('data.white_noise', 'rain');
+});
+
+/**
+ * 创建并登录普通用户。
+ *
+ * @return User
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/6/8
+ */
+function pomoSettingLoginUser(): User
+{
+    return User::query()->create([
+        'username' => 'pomo_setting_user',
+        'email' => 'pomo-setting@example.com',
+        'phone' => '13800000001',
+        'password' => bcrypt('password'),
+        'status' => 1,
+    ]);
+}

--- a/tests/Feature/Api/Admin/PomoStatsControllerTest.php
+++ b/tests/Feature/Api/Admin/PomoStatsControllerTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use App\Models\User\User;
+use Carbon\Carbon;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    Config::set('database.default', 'sqlite');
+    Config::set('database.connections.sqlite.database', ':memory:');
+    DB::purge('sqlite');
+    DB::setDefaultConnection('sqlite');
+
+    Schema::dropAllTables();
+
+    Schema::create('users', function (Blueprint $table) {
+        $table->id();
+        $table->string('username')->nullable();
+        $table->string('email')->nullable()->unique();
+        $table->string('phone')->nullable()->unique();
+        $table->string('password')->nullable();
+        $table->integer('status')->default(0);
+        $table->rememberToken();
+        $table->unsignedInteger('created_at')->default(0);
+        $table->integer('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+
+    Schema::create('roles', function (Blueprint $table) {
+        $table->id();
+        $table->string('name')->nullable();
+        $table->string('code')->nullable();
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+
+    Schema::create('user_role', function (Blueprint $table) {
+        $table->unsignedBigInteger('user_id')->default(0);
+        $table->unsignedBigInteger('role_id')->default(0);
+    });
+
+    Schema::create('pomo_tasks', function (Blueprint $table) {
+        $table->id();
+        $table->string('title', 255);
+        $table->unsignedInteger('estimated_pomos')->default(1);
+        $table->unsignedInteger('completed_pomos')->default(0);
+        $table->unsignedTinyInteger('done')->default(0);
+        $table->unsignedInteger('sort')->default(0);
+        $table->unsignedInteger('create_user')->default(0);
+        $table->unsignedInteger('created_at')->default(0);
+        $table->unsignedInteger('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+
+    Schema::create('pomo_sessions', function (Blueprint $table) {
+        $table->id();
+        $table->unsignedBigInteger('task_id')->default(0);
+        $table->char('day', 10);
+        $table->unsignedInteger('completed_at')->default(0);
+        $table->unsignedInteger('create_user')->default(0);
+        $table->unsignedInteger('created_at')->default(0);
+        $table->unsignedInteger('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+
+    // 钉死到固定日期：2026-06-08 星期一
+    Carbon::setTestNow(Carbon::create(2026, 6, 8, 10, 0, 0));
+});
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+it('记录一次完成段后近7天最后一天计数为1', function () {
+    $user = pomoStatsLoginUser();
+    $token = auth('api')->login($user);
+
+    $this->withHeader('Authorization', "Bearer {$token}")
+        ->postJson('/api/pomo/session', ['taskId' => 0])
+        ->assertOk();
+
+    $week = $this->withHeader('Authorization', "Bearer {$token}")
+        ->getJson('/api/pomo/stats/week')
+        ->assertOk()
+        ->json('data');
+
+    expect($week)->toHaveCount(7);
+    expect($week[6]['day'])->toBe('2026-06-08');
+    expect($week[6]['count'])->toBe(1);
+    expect($week[0]['day'])->toBe('2026-06-02');
+    expect($week[0]['count'])->toBe(0);
+});
+
+it('近7天统计只统计当前用户', function () {
+    DB::table('pomo_sessions')->insert([
+        'task_id' => 0, 'day' => '2026-06-08', 'completed_at' => time(),
+        'create_user' => 999, 'created_at' => time(), 'updated_at' => time(), 'deleted_at' => 0,
+    ]);
+
+    $user = pomoStatsLoginUser();
+    $token = auth('api')->login($user);
+
+    $this->withHeader('Authorization', "Bearer {$token}")
+        ->postJson('/api/pomo/session', ['taskId' => 0])
+        ->assertOk();
+
+    $week = $this->withHeader('Authorization', "Bearer {$token}")
+        ->getJson('/api/pomo/stats/week')
+        ->assertOk()
+        ->json('data');
+
+    expect($week[6]['count'])->toBe(1); // 仅自己的 1 条，不含别人的
+});
+
+/**
+ * 创建并返回普通用户。
+ *
+ * @return User
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/6/8
+ */
+function pomoStatsLoginUser(): User
+{
+    return User::query()->create([
+        'username' => 'pomo_stats_user',
+        'email' => 'pomo-stats@example.com',
+        'phone' => '13800000003',
+        'password' => bcrypt('password'),
+        'status' => 1,
+    ]);
+}

--- a/tests/Feature/Api/Admin/PomoTaskControllerTest.php
+++ b/tests/Feature/Api/Admin/PomoTaskControllerTest.php
@@ -1,0 +1,165 @@
+<?php
+
+use App\Models\Admin\PomoTask;
+use App\Models\User\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    Config::set('database.default', 'sqlite');
+    Config::set('database.connections.sqlite.database', ':memory:');
+    DB::purge('sqlite');
+    DB::setDefaultConnection('sqlite');
+
+    Schema::dropAllTables();
+
+    Schema::create('users', function (Blueprint $table) {
+        $table->id();
+        $table->string('username')->nullable();
+        $table->string('email')->nullable()->unique();
+        $table->string('phone')->nullable()->unique();
+        $table->string('password')->nullable();
+        $table->integer('status')->default(0);
+        $table->rememberToken();
+        $table->unsignedInteger('created_at')->default(0);
+        $table->integer('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+
+    Schema::create('roles', function (Blueprint $table) {
+        $table->id();
+        $table->string('name')->nullable();
+        $table->string('code')->nullable();
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+
+    Schema::create('user_role', function (Blueprint $table) {
+        $table->unsignedBigInteger('user_id')->default(0);
+        $table->unsignedBigInteger('role_id')->default(0);
+    });
+
+    Schema::create('pomo_tasks', function (Blueprint $table) {
+        $table->id();
+        $table->string('title', 255);
+        $table->unsignedInteger('estimated_pomos')->default(1);
+        $table->unsignedInteger('completed_pomos')->default(0);
+        $table->unsignedTinyInteger('done')->default(0);
+        $table->unsignedInteger('sort')->default(0);
+        $table->unsignedInteger('create_user')->default(0);
+        $table->unsignedInteger('created_at')->default(0);
+        $table->unsignedInteger('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+});
+
+it('新增任务并出现在列表', function () {
+    $user = pomoTaskLoginUser();
+    $token = auth('api')->login($user);
+
+    $this->withHeader('Authorization', "Bearer {$token}")
+        ->postJson('/api/pomo/task/add', [
+            'title' => '写周报',
+            'estimatedPomos' => 2,
+        ])
+        ->assertOk()
+        ->assertJsonPath('code', 0)
+        ->assertJsonPath('data.title', '写周报');
+
+    $this->withHeader('Authorization', "Bearer {$token}")
+        ->getJson('/api/pomo/task/index')
+        ->assertOk()
+        ->assertJsonPath('code', 0)
+        ->assertJsonPath('data.0.title', '写周报');
+});
+
+it('列表只返回当前用户任务', function () {
+    DB::table('pomo_tasks')->insert([
+        'title' => '别人的', 'estimated_pomos' => 1, 'completed_pomos' => 0,
+        'done' => 0, 'sort' => 0, 'create_user' => 999,
+        'created_at' => time(), 'updated_at' => time(), 'deleted_at' => 0,
+    ]);
+
+    $user = pomoTaskLoginUser();
+    $token = auth('api')->login($user);
+
+    $this->withHeader('Authorization', "Bearer {$token}")
+        ->postJson('/api/pomo/task/add', ['title' => '我的', 'estimatedPomos' => 1])
+        ->assertOk();
+
+    $data = $this->withHeader('Authorization', "Bearer {$token}")
+        ->getJson('/api/pomo/task/index')
+        ->assertOk()
+        ->json('data');
+
+    expect(collect($data)->pluck('title'))->toContain('我的')->not->toContain('别人的');
+});
+
+it('勾选完成切换 done 状态', function () {
+    $user = pomoTaskLoginUser();
+    $token = auth('api')->login($user);
+
+    $id = $this->withHeader('Authorization', "Bearer {$token}")
+        ->postJson('/api/pomo/task/add', ['title' => 'x', 'estimatedPomos' => 1])
+        ->json('data.id');
+
+    $this->withHeader('Authorization', "Bearer {$token}")
+        ->postJson("/api/pomo/task/toggle-done/{$id}")
+        ->assertOk()->assertJsonPath('data.done', 1);
+
+    $this->withHeader('Authorization', "Bearer {$token}")
+        ->postJson("/api/pomo/task/toggle-done/{$id}")
+        ->assertOk()->assertJsonPath('data.done', 0);
+});
+
+it('番茄数 +1', function () {
+    $user = pomoTaskLoginUser();
+    $token = auth('api')->login($user);
+
+    $id = $this->withHeader('Authorization', "Bearer {$token}")
+        ->postJson('/api/pomo/task/add', ['title' => 'x', 'estimatedPomos' => 1])
+        ->json('data.id');
+
+    $this->withHeader('Authorization', "Bearer {$token}")
+        ->postJson("/api/pomo/task/increment/{$id}")
+        ->assertOk()->assertJsonPath('data.completed_pomos', 1);
+});
+
+it('删除任务', function () {
+    $user = pomoTaskLoginUser();
+    $token = auth('api')->login($user);
+
+    $id = $this->withHeader('Authorization', "Bearer {$token}")
+        ->postJson('/api/pomo/task/add', ['title' => 'x', 'estimatedPomos' => 1])
+        ->json('data.id');
+
+    $this->withHeader('Authorization', "Bearer {$token}")
+        ->deleteJson("/api/pomo/task/{$id}")
+        ->assertOk();
+
+    expect(PomoTask::query()->whereKey($id)->exists())->toBeFalse();
+});
+
+/**
+ * 创建并返回普通用户（无 super 角色）。
+ *
+ * @return User
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/6/8
+ */
+function pomoTaskLoginUser(): User
+{
+    return User::query()->create([
+        'username' => 'pomo_task_user',
+        'email' => 'pomo-task@example.com',
+        'phone' => '13800000002',
+        'password' => bcrypt('password'),
+        'status' => 1,
+    ]);
+}

--- a/tests/Feature/Api/Admin/PomoTaskControllerTest.php
+++ b/tests/Feature/Api/Admin/PomoTaskControllerTest.php
@@ -128,7 +128,7 @@ it('番茄数 +1', function () {
 
     $this->withHeader('Authorization', "Bearer {$token}")
         ->postJson("/api/pomo/task/increment/{$id}")
-        ->assertOk()->assertJsonPath('data.completed_pomos', 1);
+        ->assertOk()->assertJsonPath('data.completedPomos', 1);
 });
 
 it('删除任务', function () {


### PR DESCRIPTION
## 概述

为个人博客新增「番茄钟 + 提醒清单」能力的**后端**（阶段一）。前端整页与右上角快控为后续阶段。

数据由全新后端承载，与现有「待办列表」(TodoItem) 完全独立。

## 改动内容

- **数据表**（3 张，按 `create_user` 隔离）：`pomo_tasks`（提醒清单）、`pomo_sessions`（完成专注记录，统计来源）、`pomo_settings`（每用户设置）
- **接口**（遵循 `backend-controller-style.md` + ServerPath/TodoItem 样板）：
  - `GET/POST /api/pomo/setting`：读取/保存设置（无则返回默认）
  - `/api/pomo/task/*`：任务 CRUD + `toggle-done` 勾选 + `increment` 番茄+1 + 批量删除
  - `POST /api/pomo/session`：记录完成专注段并给关联任务番茄数 +1
  - `GET /api/pomo/stats/week`：近 7 天每日完成番茄数（缺失补 0，本地时区）
- **菜单/权限**：个人中心下新增「专注番茄」菜单（权限码 `pomo:view`），自愈式复用已有个人中心父菜单

## 测试

- 新增 3 个 Pest 测试文件，覆盖设置读写、任务 CRUD/勾选/番茄+1、统计汇总与按用户隔离
- 远端验证：迁移 4 个 DONE；pomo 测试 9 passed；全量回归 56 passed / 1 skipped / 0 failed

## 说明

- 所有权字段用 `create_user`（对齐 TodoItem，非 user_id）
- 响应经 BaseResource 输出 camelCase