### PR TITLE
fix: 测试改用容器解析 WorkDailyReportService 修复后端 CI

### DIFF
--- a/tests/Feature/Api/Admin/WorkDailyReportHtmlRenderTest.php
+++ b/tests/Feature/Api/Admin/WorkDailyReportHtmlRenderTest.php
@@ -56,7 +56,7 @@ test('renderHtml 把 GFM Markdown 渲染成自带阅读样式的 HTML 文档', f
         . "| 指标 | 数值 |\n| --- | --- |\n| 记录条数 | 130 条 |\n\n"
         . "## 🗺️ 下一阶段计划\n\n- [ ] 继续迁移 `ECharts`\n";
 
-    $html = (new WorkDailyReportService())->renderHtml(htmlRenderMakeExport($markdown));
+    $html = app(WorkDailyReportService::class)->renderHtml(htmlRenderMakeExport($markdown));
 
     expect($html)
         ->toContain('<title>工作年报_2026</title>')
@@ -70,7 +70,7 @@ test('renderHtml 把 GFM Markdown 渲染成自带阅读样式的 HTML 文档', f
 
 // 报表正文来自外部模型生成，原始 HTML 一律剥离，防止下载的报表文件被注入脚本。
 test('renderHtml 剥离 Markdown 里的原始 HTML', function () {
-    $html = (new WorkDailyReportService())->renderHtml(
+    $html = app(WorkDailyReportService::class)->renderHtml(
         htmlRenderMakeExport("# 标题\n\n<script>alert(1)</script>正文\n")
     );
 
@@ -81,7 +81,7 @@ test('renderHtml 剥离 Markdown 里的原始 HTML', function () {
 // 这样再次预览/下载/打印拿到的都是编辑后的版本。
 test('updateExportContent 持久化编辑后的 Markdown 并影响后续渲染', function () {
     htmlRenderBootSqlite();
-    $service = new WorkDailyReportService();
+    $service = app(WorkDailyReportService::class);
 
     $export = new WorkDailyReportExport();
     $export->fill([

--- a/tests/Feature/Api/Admin/WorkDailyReportPreviousOverviewTest.php
+++ b/tests/Feature/Api/Admin/WorkDailyReportPreviousOverviewTest.php
@@ -38,7 +38,7 @@ beforeEach(function () {
         $table->unsignedInteger('deleted_at')->default(0);
     });
 
-    $this->service = new WorkDailyReportService();
+    $this->service = app(WorkDailyReportService::class);
 });
 
 function makeExport(array $attributes): WorkDailyReportExport


### PR DESCRIPTION
## 背景

后端 `blog` 仓库 CI 从 06-30 提交起连续失败（main push + 同源 PR）。

## 根因

`refactor: 抽 StyledHtmlExportService 共用带样式HTML渲染`（3a889b9）给 `WorkDailyReportService` 加了构造函数依赖：

```php
public function __construct(
    private readonly StyledHtmlExportService $styledHtmlExportService
) {}
```

但以下 4 处测试仍用**无参** `new WorkDailyReportService()` 实例化，触发 `ArgumentCountError: Too few arguments`，6 个用例失败：

- `WorkDailyReportHtmlRenderTest.php`:59 / 73 / 84
- `WorkDailyReportPreviousOverviewTest.php`:41

业务代码本身正常（`WorkDocControllerTest` 走容器解析是 PASS 的），仅测试未跟随构造签名变化。

## 改动

4 处改为 `app(WorkDailyReportService::class)`，由容器自动注入依赖。只动测试实例化，不碰业务逻辑。

## 验证（远端 Sail）

- 两个目标测试套：7 passed
- 全量 Pest：**67 passed / 1 skipped / 0 failed**（313 断言）