### PR TITLE
feat: 用户头像上传裁剪与本地存储 + Sail 升级 PHP 8.2

### DIFF
--- a/app/Http/Controllers/Api/Controller.php
+++ b/app/Http/Controllers/Api/Controller.php
@@ -7,6 +7,8 @@ use App\Services\Api\QiniuService;
 
 class Controller extends BaseController
 {
+    protected QiniuService $qiniuService;
+
     public function __construct()
     {
         $this->qiniuService = new QiniuService();

--- a/app/Http/Controllers/Api/User/AvatarController.php
+++ b/app/Http/Controllers/Api/User/AvatarController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Api\User;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\User\AvatarUploadRequest;
+use App\Http\Resources\User\UserResource;
+use App\Services\Api\User\AvatarService;
+
+class AvatarController extends Controller
+{
+    public function __construct(private readonly AvatarService $avatarService)
+    {
+    }
+
+    /**
+     * 上传并裁剪当前用户头像。
+     *
+     * @param AvatarUploadRequest $request
+     * @return UserResource
+     * @author zhouxufeng <zxf@netsun.com>
+     *
+     * @date 2026/7/7
+     */
+    public function add(AvatarUploadRequest $request): UserResource
+    {
+        $profile = $this->avatarService->update(
+            auth('api')->user(),
+            $request->file('file'),
+            $request->validated()
+        );
+
+        return new UserResource($profile);
+    }
+}

--- a/app/Http/Controllers/Api/User/UsersController.php
+++ b/app/Http/Controllers/Api/User/UsersController.php
@@ -9,6 +9,7 @@ use App\Models\User\User;
 use App\Http\Controllers\Api\Controller;
 use App\Http\Resources\User\UserResource;
 use App\Http\Requests\Api\User\UserRequest;
+use App\Services\Api\User\AvatarUrlService;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -18,6 +19,19 @@ use Spatie\QueryBuilder\QueryBuilder;
 
 class UsersController extends Controller
 {
+    /**
+     * 初始化用户控制器。
+     *
+     * @param AvatarUrlService $avatarUrlService
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     *
+     * @date 2026/7/7
+     */
+    public function __construct(private readonly AvatarUrlService $avatarUrlService)
+    {
+    }
+
     /**
      * 获取用户列表
      *
@@ -245,16 +259,14 @@ class UsersController extends Controller
      *
      * @return User|null
      * @author zhouxufeng <zxf@netsun.com>
-     * @date 2026/3/30 09:25
+     * @date 2026/7/7
      */
     protected function loadCurrentUserProfile()
     {
         $user = auth()->user();
         $user = QueryBuilder::for(User::class)->allowedIncludes('member')->with('roles')->where(['id' => $user->id])->first();
         if ($user && $user->member) {
-            $user->member->avatar = $user->member->avatar
-                ? $this->qiniuService->getPrivateUrl($user->member->avatar)
-                : "";
+            $user->member->avatar = $this->avatarUrlService->make($user->member->avatar);
         }
 
         return $user;

--- a/app/Http/Middleware/After.php
+++ b/app/Http/Middleware/After.php
@@ -23,10 +23,20 @@ class After
         // 执行动作
         if ($response instanceof JsonResponse) {
             $oriData = $response->getData();
+            $isSuccess = in_array($response->getStatusCode(), [200, 201]);
+            $errorMessage = $oriData->message ?? '操作失败';
+
+            if (! $isSuccess && isset($oriData->errors)) {
+                $errors = (array) $oriData->errors;
+                $firstMessages = reset($errors);
+                if (is_array($firstMessages) && isset($firstMessages[0])) {
+                    $errorMessage = $firstMessages[0];
+                }
+            }
 
             $message = [
-                'code' => in_array($response->getStatusCode(), [200, 201]) ? 0 : $response->getStatusCode(),
-                'msg' => in_array($response->getStatusCode(), [200, 201]) ? '操作成功' : '操作失败',
+                'code' => $isSuccess ? 0 : $response->getStatusCode(),
+                'msg' => $isSuccess ? '操作成功' : $errorMessage,
             ];
 
             $data['data'] = $oriData->data ?? $oriData ?? [];

--- a/app/Http/Requests/Api/User/AvatarUploadRequest.php
+++ b/app/Http/Requests/Api/User/AvatarUploadRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests\Api\User;
+
+use App\Http\Requests\Api\FormRequest;
+
+class AvatarUploadRequest extends FormRequest
+{
+    /**
+     * 获取头像上传校验规则。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     *
+     * @date 2026/7/7
+     */
+    public function rules(): array
+    {
+        return [
+            'file' => ['required', 'file', 'mimetypes:image/jpeg,image/png,image/gif,image/webp', 'max:5120'],
+            'crop_x' => ['required', 'integer', 'min:0'],
+            'crop_y' => ['required', 'integer', 'min:0'],
+            'crop_size' => ['required', 'integer', 'min:1'],
+        ];
+    }
+
+    /**
+     * 获取头像上传字段名称。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     *
+     * @date 2026/7/7
+     */
+    public function attributes(): array
+    {
+        return [
+            'file' => '头像文件',
+            'crop_x' => '横向裁剪位置',
+            'crop_y' => '纵向裁剪位置',
+            'crop_size' => '裁剪尺寸',
+        ];
+    }
+}

--- a/app/Services/Api/User/AvatarService.php
+++ b/app/Services/Api/User/AvatarService.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace App\Services\Api\User;
+
+use App\Models\User\Member;
+use App\Models\User\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+use RuntimeException;
+use Symfony\Component\Process\Process;
+
+class AvatarService
+{
+    private const OUTPUT_SIZE = 512;
+
+    private const MAX_DIMENSION = 3000;
+
+    private const MAX_GIF_FRAMES = 300;
+
+    /**
+     * 初始化头像处理服务。
+     *
+     * @param AvatarUrlService $avatarUrlService
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     *
+     * @date 2026/7/7
+     */
+    public function __construct(private readonly AvatarUrlService $avatarUrlService)
+    {
+    }
+
+    /**
+     * 裁剪并保存当前用户头像。
+     *
+     * @param User $user
+     * @param UploadedFile $file
+     * @param array $crop
+     * @return User
+     * @author zhouxufeng <zxf@netsun.com>
+     *
+     * @date 2026/7/7
+     */
+    public function update(User $user, UploadedFile $file, array $crop): User
+    {
+        $extension = $this->extensionForMime($file->getMimeType());
+        [$width, $height, $frames] = $this->inspect($file, $extension);
+        $this->assertImageLimits($width, $height, $frames);
+        $this->assertCropBounds($width, $height, $crop);
+
+        $processingPath = $this->processingPath($extension);
+        $relativePath = '/uploads/avatars/'.date('Ymd').'/'.Str::uuid().'.'.$extension;
+        $absolutePath = public_path($relativePath);
+        $oldPath = $user->member?->avatar;
+
+        try {
+            $this->crop($file->getRealPath(), $processingPath, $extension, $crop);
+            $this->moveToPublicDirectory($processingPath, $absolutePath);
+
+            try {
+                DB::transaction(function () use ($user, $relativePath) {
+                    $member = $user->member ?: new Member(['user_id' => (string) $user->id]);
+                    $member->avatar = $relativePath;
+                    $member->user_id = (string) $user->id;
+                    $member->edit();
+                });
+            } catch (\Throwable $exception) {
+                $this->deleteFile($absolutePath);
+                throw $exception;
+            }
+
+            if ($oldPath && $oldPath !== $relativePath) {
+                $this->deleteOldAvatar($oldPath);
+            }
+        } finally {
+            if (is_file($processingPath) && ! unlink($processingPath)) {
+                throw new RuntimeException('头像临时文件清理失败');
+            }
+        }
+
+        $profile = User::query()->with(['member', 'roles'])->findOrFail($user->id);
+        $profile->member->avatar = $this->avatarUrlService->make($relativePath);
+
+        return $profile;
+    }
+
+    /**
+     * 根据真实 MIME 获取输出扩展名。
+     *
+     * @param string|null $mime
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     *
+     * @date 2026/7/7
+     */
+    private function extensionForMime(?string $mime): string
+    {
+        return match ($mime) {
+            'image/jpeg' => 'jpg',
+            'image/png' => 'png',
+            'image/gif' => 'gif',
+            'image/webp' => 'webp',
+            default => throw ValidationException::withMessages(['file' => '头像文件格式不正确']),
+        };
+    }
+
+    /**
+     * 读取图像尺寸与帧数。
+     *
+     * @param UploadedFile $file
+     * @param string $extension
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     *
+     * @date 2026/7/7
+     */
+    private function inspect(UploadedFile $file, string $extension): array
+    {
+        $command = $extension === 'gif'
+            ? ['identify', '-format', '%w %h %n\n', $file->getRealPath()]
+            : ['convert', $file->getRealPath(), '-auto-orient', '-format', '%w %h 1\n', 'info:'];
+        $process = new Process($command);
+        $process->mustRun();
+
+        $line = strtok(trim($process->getOutput()), "\n");
+        if (! is_string($line) || ! preg_match('/^(\d+) (\d+) (\d+)$/', trim($line), $matches)) {
+            throw new RuntimeException('无法读取头像图像信息');
+        }
+
+        return [(int) $matches[1], (int) $matches[2], (int) $matches[3]];
+    }
+
+    /**
+     * 校验图像尺寸与 GIF 帧数。
+     *
+     * @param int $width
+     * @param int $height
+     * @param int $frames
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     *
+     * @date 2026/7/7
+     */
+    private function assertImageLimits(int $width, int $height, int $frames): void
+    {
+        if ($width < 1 || $height < 1 || $width > self::MAX_DIMENSION || $height > self::MAX_DIMENSION) {
+            throw ValidationException::withMessages(['file' => '头像尺寸不能超过 3000×3000 像素']);
+        }
+
+        if ($frames > self::MAX_GIF_FRAMES) {
+            throw ValidationException::withMessages(['file' => 'GIF 头像不能超过 300 帧']);
+        }
+    }
+
+    /**
+     * 校验裁剪区域没有超出原图。
+     *
+     * @param int $width
+     * @param int $height
+     * @param array $crop
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     *
+     * @date 2026/7/7
+     */
+    private function assertCropBounds(int $width, int $height, array $crop): void
+    {
+        if ($width < $crop['crop_x'] + $crop['crop_size']
+            || $height < $crop['crop_y'] + $crop['crop_size']) {
+            throw ValidationException::withMessages(['crop_size' => '头像裁剪区域超出原图范围']);
+        }
+    }
+
+    /**
+     * 生成头像处理临时路径。
+     *
+     * @param string $extension
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     *
+     * @date 2026/7/7
+     */
+    private function processingPath(string $extension): string
+    {
+        $directory = storage_path('app/avatar-processing');
+        if (! is_dir($directory) && ! mkdir($directory, 0755, true) && ! is_dir($directory)) {
+            throw new RuntimeException('头像临时目录创建失败');
+        }
+
+        return $directory.'/'.Str::uuid().'.'.$extension;
+    }
+
+    /**
+     * 执行头像裁剪与缩放。
+     *
+     * @param string $sourcePath
+     * @param string $targetPath
+     * @param string $extension
+     * @param array $crop
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     *
+     * @date 2026/7/7
+     */
+    private function crop(string $sourcePath, string $targetPath, string $extension, array $crop): void
+    {
+        $geometry = sprintf(
+            '%dx%d+%d+%d',
+            $crop['crop_size'],
+            $crop['crop_size'],
+            $crop['crop_x'],
+            $crop['crop_y']
+        );
+
+        $command = $extension === 'gif'
+            ? [
+                'convert', $sourcePath, '-coalesce', '-crop', $geometry, '+repage',
+                '-resize', self::OUTPUT_SIZE.'x'.self::OUTPUT_SIZE.'>', '-layers', 'Optimize', $targetPath,
+            ]
+            : [
+                'convert', $sourcePath, '-auto-orient', '-crop', $geometry, '+repage',
+                '-resize', self::OUTPUT_SIZE.'x'.self::OUTPUT_SIZE.'!', $targetPath,
+            ];
+
+        (new Process($command))->mustRun();
+
+        if (! is_file($targetPath) || filesize($targetPath) === 0) {
+            throw new RuntimeException('头像处理结果为空');
+        }
+    }
+
+    /**
+     * 将处理结果移动到头像公开目录。
+     *
+     * @param string $sourcePath
+     * @param string $targetPath
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     *
+     * @date 2026/7/7
+     */
+    private function moveToPublicDirectory(string $sourcePath, string $targetPath): void
+    {
+        $directory = dirname($targetPath);
+        if (! is_dir($directory) && ! mkdir($directory, 0755, true) && ! is_dir($directory)) {
+            throw new RuntimeException('头像目录创建失败');
+        }
+
+        if (! rename($sourcePath, $targetPath)) {
+            throw new RuntimeException('头像文件保存失败');
+        }
+    }
+
+    /**
+     * 删除旧的本地头像。
+     *
+     * @param string $relativePath
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     *
+     * @date 2026/7/7
+     */
+    private function deleteOldAvatar(string $relativePath): void
+    {
+        if (! str_starts_with($relativePath, '/uploads/avatars/')) {
+            return;
+        }
+
+        $this->deleteFile(public_path($relativePath));
+    }
+
+    /**
+     * 删除指定文件。
+     *
+     * @param string $path
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     *
+     * @date 2026/7/7
+     */
+    private function deleteFile(string $path): void
+    {
+        if (is_file($path) && ! unlink($path)) {
+            throw new RuntimeException('头像文件删除失败');
+        }
+    }
+}

--- a/app/Services/Api/User/AvatarUrlService.php
+++ b/app/Services/Api/User/AvatarUrlService.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Services\Api\User;
+
+use RuntimeException;
+
+class AvatarUrlService
+{
+    /**
+     * 将本地头像相对路径转换为公开访问地址。
+     *
+     * @param string $path
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     *
+     * @date 2026/7/7
+     */
+    public function make(string $path): string
+    {
+        if ($path === '' || ! str_starts_with($path, '/uploads/avatars/')) {
+            return $path;
+        }
+
+        $baseUrl = rtrim((string) config('app.url'), '/');
+        if ($baseUrl === '') {
+            throw new RuntimeException('APP_URL 未配置');
+        }
+
+        return $baseUrl.$path;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Api\User\UsersController;
 use App\Http\Controllers\Api\User\MembersController;
 use App\Http\Controllers\Api\User\MemberLevelController;
 use App\Http\Controllers\Api\User\VerificationCodesController;
+use App\Http\Controllers\Api\User\AvatarController;
 use App\Http\Controllers\Api\AuthorizationsController;
 use App\Http\Controllers\Api\MiniProgram\WallpaperController;
 use App\Http\Controllers\Api\MiniProgram\WallpaperClassifyController;
@@ -136,6 +137,8 @@ Route::name('api')->group(function () {
         Route::get('users/getUserInfo', [UsersController::class, 'getUserInfo'])->name('users.getUserInfo');
         // 更新当前用户资料
         Route::post('index/updateUserInfo', [UsersController::class, 'updateUserInfo'])->name('users.updateUserInfo');
+        // 上传当前用户头像
+        Route::post('user/avatar', [AvatarController::class, 'add'])->name('user.avatar.add');
         // 用户列表
         Route::get('users/list', [UsersController::class, 'index'])->name('users.index');
         // 验证用户

--- a/runtimes/Dockerfile
+++ b/runtimes/Dockerfile
@@ -11,7 +11,7 @@ ENV TZ=Asia/Shanghai
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev imagemagick python2 \
     && mkdir -p ~/.gnupg \
     && chmod 600 ~/.gnupg \
     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
@@ -20,15 +20,15 @@ RUN apt-get update \
     && gpg --export 0x14aa40ec0831756756d7f66c4f4ea0aae5267a6c > /usr/share/keyrings/ppa_ondrej_php.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu jammy main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \
-    && apt-get install -y php8.1-cli php8.1-dev \
-       php8.1-sqlite3 php8.1-gd \
-       php8.1-curl \
-       php8.1-imap php8.1-mysql php8.1-mbstring \
-       php8.1-xml php8.1-zip php8.1-bcmath php8.1-soap \
-       php8.1-intl php8.1-readline \
-       php8.1-ldap \
-       php8.1-msgpack php8.1-igbinary php8.1-redis php8.1-swoole \
-       php8.1-memcached php8.1-pcov php8.1-xdebug \
+    && apt-get install -y php8.2-cli php8.2-dev \
+       php8.2-sqlite3 php8.2-gd \
+       php8.2-curl \
+       php8.2-imap php8.2-mysql php8.2-mbstring \
+       php8.2-xml php8.2-zip php8.2-bcmath php8.2-soap \
+       php8.2-intl php8.2-readline \
+       php8.2-ldap \
+       php8.2-msgpack php8.2-igbinary php8.2-redis php8.2-swoole \
+       php8.2-memcached php8.2-pcov php8.2-xdebug \
     && php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
     && apt-get update \
     && apt-get install -y mysql-client \
@@ -36,14 +36,14 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.1
+RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.2
 
 RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
 
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-COPY php.ini /etc/php/8.1/cli/conf.d/99-sail.ini
+COPY php.ini /etc/php/8.2/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
 
 EXPOSE 8000

--- a/tests/Feature/Api/User/AvatarUploadTest.php
+++ b/tests/Feature/Api/User/AvatarUploadTest.php
@@ -1,0 +1,303 @@
+<?php
+
+use App\Models\User\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Symfony\Component\Process\Process;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    Config::set('app.url', 'http://10.10.9.184:3925');
+    Config::set('database.default', 'sqlite');
+    Config::set('database.connections.sqlite.database', ':memory:');
+    DB::purge('sqlite');
+    DB::setDefaultConnection('sqlite');
+
+    Schema::dropAllTables();
+    avatarUploadCreateSchema();
+    $this->avatarUploadFiles = [];
+});
+
+afterEach(function () {
+    foreach ($this->avatarUploadFiles as $path) {
+        if (is_file($path)) {
+            unlink($path);
+        }
+    }
+});
+
+it('上传并裁剪 PNG 头像到本地公开目录', function () {
+    $token = avatarUploadLoginToken();
+    DB::table('members')->insert([
+        'user_id' => '1',
+        'avatar' => 'https://cdn.example.com/legacy-avatar.png',
+    ]);
+
+    $response = $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->withHeader('Host', 'host.docker.internal:3925')
+        ->post('/api/user/avatar', [
+            'file' => UploadedFile::fake()->image('avatar.png', 240, 135),
+            'crop_x' => 52,
+            'crop_y' => 0,
+            'crop_size' => 135,
+        ]);
+
+    $response
+        ->assertOk()
+        ->assertJsonPath('code', 0);
+
+    $relativePath = DB::table('members')->value('avatar');
+    $absolutePath = public_path($relativePath);
+    $this->avatarUploadFiles[] = $absolutePath;
+    [$width, $height] = getimagesize($absolutePath);
+
+    expect($relativePath)->toStartWith('/uploads/avatars/'.date('Ymd').'/')
+        ->and($response->json('data.member.avatar'))->toBe('http://10.10.9.184:3925'.$relativePath)
+        ->and($width)->toBe(512)
+        ->and($height)->toBe(512);
+});
+
+it('个人资料接口使用 APP_URL 返回本地头像公开地址', function () {
+    $token = avatarUploadLoginToken();
+    DB::table('members')->insert([
+        'user_id' => '1',
+        'avatar' => '/uploads/avatars/20260707/profile.gif',
+    ]);
+
+    $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->withHeader('Host', 'host.docker.internal:3925')
+        ->get('/api/users/getUserInfo')
+        ->assertOk()
+        ->assertJsonPath(
+            'data.member.avatar',
+            'http://10.10.9.184:3925/uploads/avatars/20260707/profile.gif'
+        );
+});
+
+it('裁剪 GIF 后仍保留动画帧', function () {
+    $token = avatarUploadLoginToken();
+    $fixture = avatarUploadAnimatedGifFixture();
+    $this->avatarUploadFiles[] = $fixture;
+
+    $response = $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->post('/api/user/avatar', [
+            'file' => new UploadedFile($fixture, 'avatar.gif', 'image/gif', null, true),
+            'crop_x' => 0,
+            'crop_y' => 0,
+            'crop_size' => 120,
+        ]);
+
+    $response
+        ->assertOk()
+        ->assertJsonPath('code', 0);
+
+    $relativePath = DB::table('members')->value('avatar');
+    $absolutePath = public_path($relativePath);
+    $this->avatarUploadFiles[] = $absolutePath;
+    $identify = new Process(['identify', '-format', '%n\n', $absolutePath]);
+    $identify->mustRun();
+    $frames = (int) strtok(trim($identify->getOutput()), "\n");
+    [$width, $height] = getimagesize($absolutePath);
+
+    expect($relativePath)->toEndWith('.gif')
+        ->and($frames)->toBeGreaterThan(1)
+        ->and($width)->toBe(120)
+        ->and($height)->toBe(120);
+});
+
+it('超过最大尺寸的 GIF 裁剪结果缩小到 512', function () {
+    $token = avatarUploadLoginToken();
+    $fixture = avatarUploadAnimatedGifFixture(640, 640);
+    $this->avatarUploadFiles[] = $fixture;
+
+    $response = $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->post('/api/user/avatar', [
+            'file' => new UploadedFile($fixture, 'large-avatar.gif', 'image/gif', null, true),
+            'crop_x' => 20,
+            'crop_y' => 20,
+            'crop_size' => 600,
+        ]);
+
+    $response
+        ->assertOk()
+        ->assertJsonPath('code', 0);
+
+    $relativePath = DB::table('members')->value('avatar');
+    $absolutePath = public_path($relativePath);
+    $this->avatarUploadFiles[] = $absolutePath;
+    [$width, $height] = getimagesize($absolutePath);
+
+    expect($width)->toBe(512)
+        ->and($height)->toBe(512);
+});
+
+it('拒绝越界的头像裁剪区域', function () {
+    $token = avatarUploadLoginToken();
+
+    $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->post('/api/user/avatar', [
+            'file' => UploadedFile::fake()->image('avatar.png', 100, 100),
+            'crop_x' => 60,
+            'crop_y' => 0,
+            'crop_size' => 80,
+        ])
+        ->assertOk()
+        ->assertJsonPath('code', 422)
+        ->assertJsonPath('msg', '头像裁剪区域超出原图范围');
+
+    expect(DB::table('members')->count())->toBe(0);
+});
+
+/**
+ * 创建头像上传测试表结构。
+ *
+ * @return void
+ * @author zhouxufeng <zxf@netsun.com>
+ *
+ * @date 2026/7/7
+ */
+function avatarUploadCreateSchema(): void
+{
+    Schema::create('users', function (Blueprint $table) {
+        $table->id();
+        $table->string('username')->nullable();
+        $table->string('email')->nullable()->unique();
+        $table->string('phone')->nullable()->unique();
+        $table->string('openid')->nullable()->unique();
+        $table->string('unionid')->nullable()->unique();
+        $table->string('password')->nullable();
+        $table->timestamp('email_verified_at')->nullable();
+        $table->integer('status')->default(0);
+        $table->rememberToken();
+        $table->unsignedInteger('created_at')->default(0);
+        $table->integer('create_user')->default(0);
+        $table->integer('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+
+    Schema::create('members', function (Blueprint $table) {
+        $table->id();
+        $table->string('user_id', 50)->nullable();
+        $table->smallInteger('member_level')->default(0);
+        $table->string('realname', 50)->nullable();
+        $table->string('nickname', 50)->nullable();
+        $table->tinyInteger('gender')->default(3);
+        $table->string('avatar', 180)->default('');
+        $table->unsignedInteger('birthday')->default(0);
+        $table->string('province_code', 30)->nullable();
+        $table->string('city_code', 30)->nullable();
+        $table->string('district_code', 30)->nullable();
+        $table->string('address')->nullable();
+        $table->text('intro')->nullable();
+        $table->string('signature', 30)->nullable();
+        $table->string('admire')->nullable();
+        $table->boolean('device')->default(0);
+        $table->string('device_code', 40)->nullable();
+        $table->string('push_alias', 40)->default('');
+        $table->boolean('source')->default(1);
+        $table->boolean('status')->default(1);
+        $table->string('app_version', 30)->default('');
+        $table->string('code', 10)->nullable();
+        $table->string('login_ip', 30)->nullable();
+        $table->unsignedInteger('login_at')->default(0);
+        $table->string('login_region', 20)->nullable();
+        $table->unsignedInteger('login_count')->default(0);
+        $table->integer('create_user')->default(0);
+        $table->unsignedInteger('created_at')->default(0);
+        $table->integer('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+
+    Schema::create('roles', function (Blueprint $table) {
+        $table->id();
+        $table->string('name')->nullable();
+        $table->string('code')->nullable();
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+
+    Schema::create('menus', function (Blueprint $table) {
+        $table->id();
+        $table->string('permission')->nullable();
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+
+    Schema::create('user_role', function (Blueprint $table) {
+        $table->unsignedBigInteger('user_id')->default(0);
+        $table->unsignedBigInteger('role_id')->default(0);
+    });
+
+    Schema::create('role_menu', function (Blueprint $table) {
+        $table->unsignedBigInteger('role_id')->default(0);
+        $table->unsignedBigInteger('menu_id')->default(0);
+    });
+}
+
+/**
+ * 创建头像上传测试用户并返回 Token。
+ *
+ * @return string
+ * @author zhouxufeng <zxf@netsun.com>
+ *
+ * @date 2026/7/7
+ */
+function avatarUploadLoginToken(): string
+{
+    $user = User::query()->create([
+        'username' => 'avatar_upload_user',
+        'email' => 'avatar-upload@example.com',
+        'phone' => '13800000001',
+        'password' => bcrypt('password'),
+        'status' => 1,
+    ]);
+
+    return auth('api')->login($user);
+}
+
+/**
+ * 创建两帧 GIF 测试文件。
+ *
+ * @param int $width
+ * @param int $height
+ * @return string
+ * @author zhouxufeng <zxf@netsun.com>
+ *
+ * @date 2026/7/7
+ */
+function avatarUploadAnimatedGifFixture(int $width = 160, int $height = 120): string
+{
+    $directory = storage_path('app/avatar-test');
+    if (! is_dir($directory)) {
+        mkdir($directory, 0755, true);
+    }
+
+    $prefix = $directory.'/'.uniqid('avatar-', true);
+    $firstPath = $prefix.'-1.png';
+    $secondPath = $prefix.'-2.png';
+    $gifPath = $prefix.'.gif';
+
+    foreach ([[$firstPath, [32, 201, 178]], [$secondPath, [214, 255, 114]]] as [$path, $rgb]) {
+        $image = imagecreatetruecolor($width, $height);
+        $color = imagecolorallocate($image, ...$rgb);
+        imagefill($image, 0, 0, $color);
+        imagepng($image, $path);
+        imagedestroy($image);
+    }
+
+    (new Process(['convert', '-delay', '8', '-loop', '0', $firstPath, $secondPath, $gifPath]))->mustRun();
+    unlink($firstPath);
+    unlink($secondPath);
+
+    return $gifPath;
+}


### PR DESCRIPTION
## 背景
配套前端头像裁剪（blog-ui-vue3 #72）：后端提供 `POST user/avatar` 上传裁剪接口；修复 GIF 上传 405 与头像地址生成错误；Sail 运行时升级 PHP 8.2 并安装 ImageMagick。

## 改动
- 新增 `POST user/avatar`：`AvatarController`（构造注入）+ `AvatarUploadRequest`（类型 JPG/PNG/GIF/WebP、`max:5120`、`crop_x/y/size` 校验）
- `AvatarService` 用 ImageMagick CLI 裁剪：GIF 走 `-coalesce` 保留动画帧、超限缩至 `512`；存本地公开目录并清理旧头像
- `AvatarUrlService` 统一生成头像公开地址（`APP_URL`），替换 qiniu 私有 URL，修复头像地址生成错误
- `After` 中间件失败响应透传首条校验错误（原一律「操作失败」）
- Sail runtime PHP `8.1 → 8.2`（补齐 `composer.json ^8.2` 声明）+ 系统 `imagemagick`；GIF 保存约 `37.04s → 4.20s`
- `Api\Controller` 声明 `qiniuService` 属性，消除 PHP 8.2 动态属性弃用告警

## 测试
- 新增 `AvatarUploadTest`（Pest，5 用例）：PNG 裁剪落盘 / GIF 动画帧保留 / 超限缩小 / 越界拒绝 / `APP_URL` 地址生成
- 远端 PHP 8.2.32 容器全量：`72 passed, 1 skipped (335 assertions)`（skip 为既有环境性跳过，与本次无关）

## 运维提示
- 改了 `runtimes/Dockerfile`，部署需重建镜像（远端测试环境已重建并验证）