### PR TITLE
docs: 后端 PHP 8.2 / ImageMagick 说明 + setup.sh 纳入版本管理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 /public/hot
 /public/storage
 public/uploads
-setup.sh
 /storage/*.key
 /vendor
 .env

--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@
 
 | 项目 | 当前情况 |
 | --- | --- |
-| PHP | `^8.1` |
+| PHP | `^8.2` |
 | Laravel | `^10.10` |
 | 运行方式 | Laravel Sail，入口是 `docker-compose.yml` |
 | 应用服务名 | `blog` |
 | 数据库 | MySQL 8.0 |
 | 缓存 | Redis Alpine |
 | 邮件调试 | Mailpit |
+| 图像处理 | ImageMagick（头像上传裁剪用，由 `runtimes/Dockerfile` 安装，`sail build` 时生效）|
 | 登录认证 | `php-open-source-saver/jwt-auth` |
-| 测试 | PHPUnit 10，入口是 `php artisan test` |
+| 测试 | Pest 2（基于 PHPUnit 10），入口是 `./vendor/bin/sail pest` |
 | 资源构建 | Vite 4，仅用于 Laravel `resources/` 资源 |
 
 ## 目录结构
@@ -118,7 +119,7 @@ MAIL_PORT=${FORWARD_MAILPIT_PORT}
 docker run --rm \
   -v "$(pwd)":/opt \
   -w /opt \
-  laravelsail/php81-composer:latest \
+  laravelsail/php82-composer:latest \
   composer install --ignore-platform-reqs
 ```
 
@@ -247,10 +248,11 @@ npm run build
 
 ## 测试
 
-后端测试入口：
+测试统一用 **Pest** 格式，一律在（远端）Sail 容器里跑：
 
 ```bash
-./vendor/bin/sail artisan test
+./vendor/bin/sail pest            # 全量
+./vendor/bin/sail pest tests/Feature/Api/User/AvatarUploadTest.php   # 单文件
 ```
 
 当前测试目录：
@@ -258,4 +260,4 @@ npm run build
 | 路径 | 内容 |
 | --- | --- |
 | `tests/Unit` | Filter、MenuService、迁移辅助逻辑等单元测试 |
-| `tests/Feature` | HTTP 功能测试 |
+| `tests/Feature` | HTTP 功能测试（Pest 格式）|

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,35 @@
+docker info > /dev/null 2>&1
+
+# Ensure that Docker is running...
+if [ $? -ne 0 ]; then
+    echo "Docker is not running."
+    exit 1
+fi
+
+docker run --rm \
+    --pull=always \
+    -v "$(pwd)":/opt \
+    -w /opt \
+    laravelsail/php82-composer:latest \
+    bash -c "composer install --ignore-platform-reqs && php ./artisan sail:install --with=mysql,redis,mailpit "
+
+./vendor/bin/sail pull mysql redis mailpit
+./vendor/bin/sail build
+
+CYAN='\033[0;36m'
+LIGHT_CYAN='\033[1;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+echo ""
+
+if sudo -n true 2>/dev/null; then
+    sudo chown -R $USER: .
+    echo -e "${BOLD}Get started with:${NC} ./vendor/bin/sail up"
+else
+    echo -e "${BOLD}Please provide your password so we can make some final adjustments to your application's permissions.${NC}"
+    echo ""
+    sudo chown -R $USER: .
+    echo ""
+    echo -e "${BOLD}Thank you! We hope you build something incredible. Dive in with:${NC} ./vendor/bin/sail up"
+fi


### PR DESCRIPTION
配合本次 Sail 升级 PHP 8.2 + 安装 ImageMagick（#35），同步安装引导与文档。

## 改动
- `setup.sh` 从 `.gitignore` 移除、纳入版本管理；首次安装引导 composer 镜像 `laravelsail/php81-composer → php82-composer`，与运行时 PHP 8.2 对齐
- `README.md` 技术栈 PHP `^8.1 → ^8.2`，新增 ImageMagick 行（头像裁剪，`runtimes/Dockerfile` 安装）
- `README.md` 安装依赖引导镜像 `php81 → php82`
- `README.md` 测试口径由 `PHPUnit / artisan test` 更正为 **Pest**（入口 `./vendor/bin/sail pest`），与项目实际测试格式一致