### PR TITLE
fix: CI 安装 ImageMagick 修复头像测试失败

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
           extensions: mbstring, curl, simplexml, pdo_mysql, sqlite3, pdo_sqlite, bcmath, gd, exif, zip
           coverage: none
 
+      - name: Install ImageMagick
+        # 头像上传裁剪用 convert CLI 处理图片，与 runtimes/Dockerfile 一致
+        run: sudo apt-get update && sudo apt-get install -y imagemagick
+
       - name: Prepare environment
         run: |
           cp .env.example .env


### PR DESCRIPTION
## 问题
#35 引入的 `AvatarUploadTest` 走 `convert` CLI 处理图片，但 CI runner 未装 ImageMagick，报 `sh: 1: exec: convert: not found`，4 个头像用例失败（`Tests: 4 failed, 69 passed`）。远端 sail 容器有 ImageMagick，所以本地验证是绿的、CI 才暴露。

## 修复
- CI 工作流新增 `Install ImageMagick` 步骤（`apt-get install imagemagick`），与 `runtimes/Dockerfile` 一致，提供 `convert` 命令