### PR TITLE
开发管理新增平台脚本：sinoloans 放款测试一键推送

### DIFF
--- a/app/Http/Controllers/Api/Admin/PlatformScriptController.php
+++ b/app/Http/Controllers/Api/Admin/PlatformScriptController.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Api\Controller;
+use App\Http\Requests\Api\Admin\PlatformScriptRequest;
+use App\Http\Resources\BaseResource;
+use App\Models\Admin\PlatformScriptRun;
+use App\Services\Api\Admin\PlatformScript\PlatformScriptService;
+use Illuminate\Http\JsonResponse;
+use Spatie\QueryBuilder\QueryBuilder;
+
+class PlatformScriptController extends Controller
+{
+    /**
+     * 初始化平台脚本服务。
+     *
+     * @param PlatformScriptService $platformScriptService
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    public function __construct(private readonly PlatformScriptService $platformScriptService)
+    {
+        parent::__construct();
+    }
+
+    /**
+     * 执行记录列表 - 分页
+     *
+     * @param PlatformScriptRequest $request
+     * @param PlatformScriptRun $platformScriptRun
+     * @return BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    public function index(PlatformScriptRequest $request, PlatformScriptRun $platformScriptRun)
+    {
+        $allowedFilters = $request->generateAllowedFilters($platformScriptRun->getRequestFilters());
+
+        $runs = QueryBuilder::for($platformScriptRun)
+            ->allowedFilters($allowedFilters)
+            ->orderByDesc('id')
+            ->paginate($request->perPage());
+
+        return $this->resource($runs, ['time' => true, 'collection' => true]);
+    }
+
+    /**
+     * 解析预览：返回字段与将要使用的 ordrNo，不发送。
+     *
+     * @param PlatformScriptRequest $request
+     * @return JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    public function preview(PlatformScriptRequest $request): JsonResponse
+    {
+        return response()->json($this->platformScriptService->preview(
+            $request->validated('script_key'),
+            $request->validated('text'),
+        ));
+    }
+
+    /**
+     * 执行推送：解析、自增 ordrNo、SSH 远端执行并落库。
+     *
+     * @param PlatformScriptRequest $request
+     * @return BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    public function run(PlatformScriptRequest $request)
+    {
+        $run = $this->platformScriptService->run(
+            $request->validated('script_key'),
+            $request->validated('text'),
+        );
+
+        return $this->resource($run);
+    }
+
+    /**
+     * 执行记录详情
+     *
+     * @param PlatformScriptRun $platformScriptRun
+     * @return BaseResource
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    public function info(PlatformScriptRun $platformScriptRun)
+    {
+        return $this->resource($platformScriptRun);
+    }
+}

--- a/app/Http/Requests/Api/Admin/PlatformScriptRequest.php
+++ b/app/Http/Requests/Api/Admin/PlatformScriptRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Requests\Api\Admin;
+
+use App\Http\Requests\Api\FormRequest;
+
+class PlatformScriptRequest extends FormRequest
+{
+    /**
+     * 获取平台脚本接口校验规则。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    public function rules(): array
+    {
+        $method = $this->route()->getActionMethod();
+
+        return match ($method) {
+            'index' => array_merge($this->paginationRules(), [
+                'script_key' => ['nullable', 'string', 'max:64'],
+                'filter' => ['nullable', 'array'],
+                'filter.script_key' => ['nullable', 'string', 'max:64'],
+                'filter.ordr_no' => ['nullable', 'string', 'max:40'],
+                'filter.appl_id' => ['nullable', 'string', 'max:64'],
+            ]),
+            'preview', 'run' => [
+                'script_key' => ['required', 'string', 'max:64'],
+                'text' => ['required', 'string'],
+            ],
+            default => [],
+        };
+    }
+
+    /**
+     * 获取平台脚本字段别名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    public function attributes(): array
+    {
+        return array_merge($this->paginationAttributes(), [
+            'script_key' => '脚本标识',
+            'text' => '推送文本',
+        ]);
+    }
+}

--- a/app/Models/Admin/PlatformScriptRun.php
+++ b/app/Models/Admin/PlatformScriptRun.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models\Admin;
+
+use App\Models\BaseModel;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class PlatformScriptRun extends BaseModel
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'script_key',
+        'ordr_no',
+        'appl_id',
+        'cntrct_no',
+        'cntpr_nme',
+        'cust_bank_acct_no',
+        'cust_pay_amt',
+        'actcpe_bchnw_id',
+        'actope_bchnw_nme',
+        'raw_text',
+        'request_data',
+        'output',
+        'status',
+        'error',
+    ];
+
+    /**
+     * 过滤参数配置
+     *
+     * @var array[]
+     */
+    protected $requestFilters = [
+        'script_key' => ['column' => 'script_key'],
+        'ordr_no' => ['column' => 'ordr_no'],
+        'appl_id' => ['column' => 'appl_id'],
+    ];
+}

--- a/app/Services/Api/Admin/PlatformScript/PlatformScriptService.php
+++ b/app/Services/Api/Admin/PlatformScript/PlatformScriptService.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Services\Api\Admin\PlatformScript;
+
+use App\Models\Admin\PlatformScriptRun;
+use App\Services\Api\Admin\PlatformScript\Scripts\SinoloansComm3LoanScript;
+use App\Services\Api\Admin\PlatformScript\Support\SshRunner;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * 平台脚本编排：解析预览、执行推送、落库存档。
+ *
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/7/23
+ */
+class PlatformScriptService
+{
+    public function __construct(private readonly SshRunner $sshRunner)
+    {
+    }
+
+    /**
+     * 解析预览：返回字段与将要使用的 ordrNo，不发送、不落库。
+     *
+     * @param string $scriptKey
+     * @param string $text
+     * @return array{script_key: string, fields: array<string, string>, ordr_no: string}
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    public function preview(string $scriptKey, string $text): array
+    {
+        $script = $this->resolveScript($scriptKey);
+        $fields = $this->parseOrFail($script, $text);
+        $ordrNo = $script->nextOrdrNo($this->lastOrdrNo($scriptKey));
+
+        return [
+            'script_key' => $scriptKey,
+            'fields' => $fields,
+            'ordr_no' => $ordrNo,
+        ];
+    }
+
+    /**
+     * 执行推送：解析 -> 自增 ordrNo -> SSH 远端执行 -> 落库。
+     *
+     * @param string $scriptKey
+     * @param string $text
+     * @return PlatformScriptRun
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    public function run(string $scriptKey, string $text): PlatformScriptRun
+    {
+        $script = $this->resolveScript($scriptKey);
+        $fields = $this->parseOrFail($script, $text);
+        $ordrNo = $script->nextOrdrNo($this->lastOrdrNo($scriptKey));
+        $requestData = $script->buildRequestData($fields, $ordrNo);
+        $requestJson = json_encode($requestData, JSON_UNESCAPED_UNICODE);
+        $command = $script->command(bin2hex($requestJson));
+        $connection = $script->connection();
+
+        $run = new PlatformScriptRun();
+        $run->fill(array_merge($fields, [
+            'script_key' => $scriptKey,
+            'ordr_no' => $ordrNo,
+            'raw_text' => $text,
+            'request_data' => $requestJson,
+        ]));
+
+        try {
+            $result = $this->sshRunner->run($connection, $command);
+            $run->output = $result['output'];
+
+            if (!empty($result['timed_out'])) {
+                // 超时不当作成功：远端可能仍在跑、输出多半没读回，是否已送达无法从这里判断
+                $run->status = 'timeout';
+                $run->error = '远端执行超时（超过 ' . ((int) ($connection['timeout'] ?? 120))
+                    . ' 秒），银行网关未在时限内返回，无法确认本次是否已送达，请到 sinoloans 侧日志确认。';
+            } else {
+                $run->status = 'success';
+            }
+        } catch (\Throwable $e) {
+            $run->output = '';
+            $run->status = 'failed';
+            $run->error = $e->getMessage();
+        }
+
+        $run->edit();
+
+        return $run;
+    }
+
+    /**
+     * 按脚本标识解析脚本处理器。新增脚本在此登记分支。
+     *
+     * @param string $scriptKey
+     * @return SinoloansComm3LoanScript
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    private function resolveScript(string $scriptKey): SinoloansComm3LoanScript
+    {
+        $config = config('platform-script.scripts.' . $scriptKey);
+
+        if (empty($config)) {
+            throw ValidationException::withMessages(['script_key' => '未知脚本：' . $scriptKey]);
+        }
+
+        return match ($scriptKey) {
+            SinoloansComm3LoanScript::KEY => new SinoloansComm3LoanScript($config),
+            default => throw ValidationException::withMessages(['script_key' => '未知脚本：' . $scriptKey]),
+        };
+    }
+
+    /**
+     * 解析粘贴文本，失败时转成 422 校验异常，避免 500。
+     *
+     * @param SinoloansComm3LoanScript $script
+     * @param string $text
+     * @return array<string, string>
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    private function parseOrFail(SinoloansComm3LoanScript $script, string $text): array
+    {
+        try {
+            return $script->parse($text);
+        } catch (\InvalidArgumentException $e) {
+            throw ValidationException::withMessages(['text' => $e->getMessage()]);
+        }
+    }
+
+    /**
+     * 取某脚本历史最大 ordrNo（定宽补零，字典序即数值序）。
+     *
+     * @param string $scriptKey
+     * @return string|null
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    private function lastOrdrNo(string $scriptKey): ?string
+    {
+        return PlatformScriptRun::query()
+            ->where('script_key', $scriptKey)
+            ->orderByDesc('ordr_no')
+            ->value('ordr_no');
+    }
+}

--- a/app/Services/Api/Admin/PlatformScript/Scripts/SinoloansComm3LoanScript.php
+++ b/app/Services/Api/Admin/PlatformScript/Scripts/SinoloansComm3LoanScript.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace App\Services\Api\Admin\PlatformScript\Scripts;
+
+/**
+ * sinoloans 放款测试推送脚本。
+ *
+ * 把银行发来的申请文本解析成 comm3-test loan 的请求字段，生成自增 ordrNo，
+ * 组装成远端 loanAction 需要的请求结构，并给出远端执行命令。
+ *
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/7/23
+ */
+class SinoloansComm3LoanScript
+{
+    public const KEY = 'sinoloans-comm3-loan';
+
+    /**
+     * 粘贴标签 => 目标字段。值为可接受的标签子串（容忍别名）。
+     *
+     * @var array<string, string[]>
+     */
+    private const LABEL_MAP = [
+        'appl_id'           => ['申请编号'],
+        'cust_bank_acct_no' => ['收款银行账户', '收款账户'],
+        'cntrct_no'         => ['合同号'],
+        'cust_pay_amt'      => ['提款金额'],
+        'cntpr_nme'         => ['交易对手户名', '交易对手名', '交易对手'],
+        'actcpe_bchnw_id'   => ['开户网点号'],
+        'actope_bchnw_nme'  => ['开户网点名'],
+    ];
+
+    /**
+     * @param array $config 该脚本在 config/platform-script.php 的配置片段
+     */
+    public function __construct(private readonly array $config)
+    {
+    }
+
+    /**
+     * 解析粘贴文本为 7 个请求字段。
+     *
+     * @param string $text
+     * @return array<string, string>
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    public function parse(string $text): array
+    {
+        $fields = [];
+
+        foreach (preg_split('/\r\n|\r|\n/', $text) as $line) {
+            // 按首个中英文冒号拆分标签与值
+            $parts = preg_split('/[:：]/u', $line, 2);
+            if (count($parts) < 2) {
+                continue;
+            }
+
+            $label = preg_replace('/\s+/u', '', $parts[0]);
+            // 去掉值两端空白及中英文逗号（用 /u 按字符处理，避免字节裁剪破坏尾部中文，如「行」被误删尾字节）
+            $value = preg_replace('/^[\s,，]+|[\s,，]+$/u', '', $parts[1]);
+
+            if ($label === '' || $value === '') {
+                continue;
+            }
+
+            foreach (self::LABEL_MAP as $field => $aliases) {
+                if (isset($fields[$field])) {
+                    continue;
+                }
+                foreach ($aliases as $alias) {
+                    if (str_contains($label, $alias)) {
+                        $fields[$field] = $value;
+                        break 2;
+                    }
+                }
+            }
+        }
+
+        $missing = array_diff(array_keys(self::LABEL_MAP), array_keys($fields));
+        if (!empty($missing)) {
+            $labels = array_map(static fn($f) => self::LABEL_MAP[$f][0], $missing);
+            throw new \InvalidArgumentException('缺少字段：' . implode('、', $labels));
+        }
+
+        return $fields;
+    }
+
+    /**
+     * 根据历史最大 ordrNo 计算下一个（无历史时以种子 +1）。
+     *
+     * @param string|null $lastOrdrNo 历史最大 ordrNo
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    public function nextOrdrNo(?string $lastOrdrNo): string
+    {
+        $prefix = $this->config['ordr_no_prefix'];
+        $digits = (int) $this->config['ordr_no_digits'];
+
+        $base = $lastOrdrNo ?: $this->config['ordr_no_seed'];
+        $number = (int) substr($base, strlen($prefix)) + 1;
+
+        return $prefix . str_pad((string) $number, $digits, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * 组装远端 loanAction 需要的请求结构。
+     *
+     * @param array<string, string> $fields
+     * @param string $ordrNo
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    public function buildRequestData(array $fields, string $ordrNo): array
+    {
+        return [
+            'applId' => $fields['appl_id'],
+            'ordrNo' => $ordrNo,
+            'transferItemList' => [
+                [
+                    'cntrctNo' => $fields['cntrct_no'],
+                    'cntprNme' => $fields['cntpr_nme'],
+                    'custBankAcctNo' => $fields['cust_bank_acct_no'],
+                    'custPayAmt' => $fields['cust_pay_amt'],
+                    'actcpeBchnwId' => $fields['actcpe_bchnw_id'],
+                    'actopeBchnwNme' => $fields['actope_bchnw_nme'],
+                ],
+            ],
+            'remark1' => '',
+            'remark2' => '',
+            'remark3' => '',
+        ];
+    }
+
+    /**
+     * 远端执行命令。payload 用 hex 编码：远端 CLI 路由以 explode("=") 拆参，base64 的 "=" 补位会被截断。
+     *
+     * @param string $payloadHex
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    public function command(string $payloadHex): string
+    {
+        return sprintf(
+            'cd %s && %s payload=%s',
+            $this->config['remote_path'],
+            $this->config['script_command'],
+            $payloadHex
+        );
+    }
+
+    /**
+     * 该脚本使用的 SSH 连接配置。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    public function connection(): array
+    {
+        return config('platform-script.connections.' . $this->config['connection']);
+    }
+}

--- a/app/Services/Api/Admin/PlatformScript/Support/SshRunner.php
+++ b/app/Services/Api/Admin/PlatformScript/Support/SshRunner.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Services\Api\Admin\PlatformScript\Support;
+
+use phpseclib3\Net\SSH2;
+
+/**
+ * 通用 SSH 执行器：在远端主机执行命令并返回输出。
+ *
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/7/23
+ */
+class SshRunner
+{
+    /**
+     * 在远端执行命令。
+     *
+     * @param array $connection host/port/username/password/timeout
+     * @param string $command
+     * @return array{output: string, exit_status: int|null, timed_out: bool}
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    public function run(array $connection, string $command): array
+    {
+        if (empty($connection['password'])) {
+            throw new \RuntimeException('SSH 密码未配置，请在 .env 设置 SINOLOANS_SSH_PASSWORD');
+        }
+
+        $timeout = (int) ($connection['timeout'] ?? 120);
+
+        $ssh = new SSH2($connection['host'], (int) $connection['port'], $timeout);
+        $ssh->setTimeout($timeout);
+
+        if (!$ssh->login($connection['username'], $connection['password'])) {
+            throw new \RuntimeException('SSH 登录失败：' . $connection['username'] . '@' . $connection['host']);
+        }
+
+        $output = $ssh->exec($command);
+
+        return [
+            'output' => is_string($output) ? $output : '',
+            'exit_status' => $ssh->getExitStatus() === false ? null : $ssh->getExitStatus(),
+            // 命令未在超时时限内结束时为 true（远端仍可能在跑，输出多半没读回）
+            'timed_out' => $ssh->isTimeout(),
+        ];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "overtrue/laravel-socialite": "^4.1",
         "overtrue/laravel-wechat": "^7.3",
         "php-open-source-saver/jwt-auth": "^2.1",
+        "phpseclib/phpseclib": "^3.0",
         "propaganistas/laravel-phone": "^5.0",
         "spatie/laravel-backup": "^8.8",
         "spatie/laravel-query-builder": "^5.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1d1c25bbe92f74aa367645c0adc78573",
+    "content-hash": "6cbcb4f991562d2a9cfdfc2d16f43a13",
     "packages": [
         {
             "name": "brick/math",
@@ -4233,6 +4233,125 @@
             "time": "2024-03-08T06:41:54+00:00"
         },
         {
+            "name": "paragonie/constant_time_encoding",
+            "version": "v3.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/constant_time_encoding.git",
+                "reference": "d5b01a39b3415c2cd581d3bd3a3575c1ebbd8e77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/d5b01a39b3415c2cd581d3bd3a3575c1ebbd8e77",
+                "reference": "d5b01a39b3415c2cd581d3bd3a3575c1ebbd8e77",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8"
+            },
+            "require-dev": {
+                "infection/infection": "^0",
+                "nikic/php-fuzzer": "^0",
+                "phpunit/phpunit": "^9|^10|^11",
+                "vimeo/psalm": "^4|^5|^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParagonIE\\ConstantTime\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Steve 'Sc00bz' Thomas",
+                    "email": "steve@tobtu.com",
+                    "homepage": "https://www.tobtu.com",
+                    "role": "Original Developer"
+                }
+            ],
+            "description": "Constant-time Implementations of RFC 4648 Encoding (Base-64, Base-32, Base-16)",
+            "keywords": [
+                "base16",
+                "base32",
+                "base32_decode",
+                "base32_encode",
+                "base64",
+                "base64_decode",
+                "base64_encode",
+                "bin2hex",
+                "encoding",
+                "hex",
+                "hex2bin",
+                "rfc4648"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/constant_time_encoding/issues",
+                "source": "https://github.com/paragonie/constant_time_encoding"
+            },
+            "time": "2025-09-24T15:06:41+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v9.99.100",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/random_compat/issues",
+                "source": "https://github.com/paragonie/random_compat"
+            },
+            "time": "2020-10-15T08:29:30+00:00"
+        },
+        {
             "name": "php-open-source-saver/jwt-auth",
             "version": "2.1.0",
             "source": {
@@ -4508,6 +4627,116 @@
                 }
             ],
             "time": "2025-12-27T19:41:33+00:00"
+        },
+        {
+            "name": "phpseclib/phpseclib",
+            "version": "3.0.55",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpseclib/phpseclib.git",
+                "reference": "db9744e6d47e742b1f974e965ad49bdd041105af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/db9744e6d47e742b1f974e965ad49bdd041105af",
+                "reference": "db9744e6d47e742b1f974e965ad49bdd041105af",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/constant_time_encoding": "^1|^2|^3",
+                "paragonie/random_compat": "^1.4|^2.0|^9.99.99",
+                "php": ">=5.6.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "suggest": {
+                "ext-dom": "Install the DOM extension to load XML formatted public keys.",
+                "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
+                "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
+                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
+                "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "phpseclib/bootstrap.php"
+                ],
+                "psr-4": {
+                    "phpseclib3\\": "phpseclib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jim Wigginton",
+                    "email": "terrafrost@php.net",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Patrick Monnerat",
+                    "email": "pm@datasphere.ch",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Andreas Fischer",
+                    "email": "bantu@phpbb.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Hans-Jürgen Petrich",
+                    "email": "petrich@tronic-media.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
+            "homepage": "http://phpseclib.sourceforge.net",
+            "keywords": [
+                "BigInteger",
+                "aes",
+                "asn.1",
+                "asn1",
+                "blowfish",
+                "crypto",
+                "cryptography",
+                "encryption",
+                "rsa",
+                "security",
+                "sftp",
+                "signature",
+                "signing",
+                "ssh",
+                "twofish",
+                "x.509",
+                "x509"
+            ],
+            "support": {
+                "issues": "https://github.com/phpseclib/phpseclib/issues",
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.55"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/terrafrost",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpseclib",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpseclib/phpseclib",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-14T23:24:10+00:00"
         },
         {
             "name": "propaganistas/laravel-phone",
@@ -12549,8 +12778,8 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2",
-        "ext-simplexml": "*",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "ext-simplexml": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/config/platform-script.php
+++ b/config/platform-script.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Services\Api\Admin\PlatformScript\Scripts\SinoloansComm3LoanScript;
+
+return [
+    // 默认脚本（前端下拉默认项，为将来多脚本留位）
+    'default_script' => SinoloansComm3LoanScript::KEY,
+
+    // 已注册脚本。新增脚本时在此登记，并在 PlatformScriptService::resolveScript 里补一个分支。
+    'scripts' => [
+        SinoloansComm3LoanScript::KEY => [
+            'name' => 'sinoloans 交行个经贷放款测试推送',
+            'connection' => 'sinoloans',
+            'remote_path' => env('SINOLOANS_REMOTE_PATH', '/var/www/html/toocle/sinoloans'),
+            'script_command' => 'php public/script.php controller=comm3-test action=loan',
+            'ordr_no_prefix' => 'SYBG',
+            // ordrNo 数字部分补零位数（SYBG + 16 位 = 20 位）
+            'ordr_no_digits' => 16,
+            // 无历史时的种子（脚本当前写死值），下一个自增为 56
+            'ordr_no_seed' => 'SYBG0000000000000055',
+        ],
+    ],
+
+    // SSH 连接配置。密码等敏感信息只走 .env，不写默认值，缺失时由 SshRunner 直接报错。
+    'connections' => [
+        'sinoloans' => [
+            'host' => env('SINOLOANS_SSH_HOST', 'www2.dev.sinoloans.cn'),
+            'port' => (int) env('SINOLOANS_SSH_PORT', 22),
+            'username' => env('SINOLOANS_SSH_USERNAME', 'sinoloans'),
+            'password' => env('SINOLOANS_SSH_PASSWORD'),
+            'timeout' => (int) env('SINOLOANS_SSH_TIMEOUT', 120),
+        ],
+    ],
+];

--- a/database/migrations/2026_07_23_000000_create_platform_script_runs_table.php
+++ b/database/migrations/2026_07_23_000000_create_platform_script_runs_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('platform_script_runs', function (Blueprint $table) {
+            $table->id()->comment('主键ID');
+            $table->string('script_key', 64)->index('index_script_key')->comment('脚本标识');
+            $table->string('ordr_no', 40)->index('index_ordr_no')->comment('订单号');
+            $table->string('appl_id', 64)->default('')->comment('申请编号');
+            $table->string('cntrct_no', 64)->default('')->comment('合同号');
+            $table->string('cntpr_nme', 128)->default('')->comment('交易对手户名');
+            $table->string('cust_bank_acct_no', 64)->default('')->comment('收款银行账户');
+            $table->string('cust_pay_amt', 32)->default('')->comment('提款金额');
+            $table->string('actcpe_bchnw_id', 64)->default('')->comment('开户网点号');
+            $table->string('actope_bchnw_nme', 255)->default('')->comment('开户网点名');
+            $table->text('raw_text')->comment('原始粘贴文本');
+            $table->text('request_data')->comment('组装后的请求报文JSON');
+            $table->longText('output')->comment('远端执行输出');
+            $table->string('status', 16)->comment('执行状态：success/failed');
+            $table->text('error')->nullable()->comment('失败信息');
+            $table->unsignedInteger('create_user')->default(0)->comment('创建人');
+            $table->unsignedInteger('created_at')->default(0)->comment('添加时间');
+            $table->unsignedInteger('update_user')->default(0)->comment('更新人');
+            $table->unsignedInteger('updated_at')->default(0)->comment('更新时间');
+            $table->unsignedInteger('deleted_at')->default(0)->comment('删除时间');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('platform_script_runs');
+    }
+};

--- a/database/migrations/2026_07_23_000100_add_platform_script_menu.php
+++ b/database/migrations/2026_07_23_000100_add_platform_script_menu.php
@@ -1,0 +1,149 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class AddPlatformScriptMenu extends Migration
+{
+    /**
+     * 在「开发管理」下新增「平台脚本」菜单。
+     *
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    public function up(): void
+    {
+        $developId = $this->developMenuId();
+        if (!$developId) {
+            return;
+        }
+
+        $menuId = $this->upsertMenu('/develop/platform-script', [
+            'pid' => $developId,
+            'title' => '平台脚本',
+            'icon' => 'el-icon-s-promotion',
+            'component' => '/develop/platform-script',
+            'target' => '_self',
+            'permission' => 'dev:platformScript:view',
+            'type' => 0,
+            'status' => 1,
+            'hide' => 0,
+            'note' => '',
+            'sort' => 70,
+        ]);
+
+        $this->grantToAdminRoles([$menuId]);
+    }
+
+    /**
+     * 删除「平台脚本」菜单。
+     *
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    public function down(): void
+    {
+        $ids = DB::table('menus')
+            ->where('path', '/develop/platform-script')
+            ->pluck('id')
+            ->all();
+
+        if (!$ids) {
+            return;
+        }
+
+        DB::table('role_menu')->whereIn('menu_id', $ids)->delete();
+        DB::table('menus')->whereIn('id', $ids)->delete();
+    }
+
+    /**
+     * 查询「开发管理」父菜单 id。
+     *
+     * @return int|null
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    private function developMenuId(): ?int
+    {
+        $develop = DB::table('menus')
+            ->where('path', '/develop')
+            ->where('type', 0)
+            ->first();
+
+        return $develop ? (int) $develop->id : null;
+    }
+
+    /**
+     * 新增或更新菜单。
+     *
+     * @param string $path
+     * @param array $data
+     * @return int
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    private function upsertMenu(string $path, array $data): int
+    {
+        $now = time();
+        $existing = DB::table('menus')
+            ->where('path', $path)
+            ->where('type', 0)
+            ->first();
+
+        $payload = array_merge($data, [
+            'path' => $path,
+            'update_user' => 0,
+            'updated_at' => $now,
+            'deleted_at' => 0,
+        ]);
+
+        if ($existing) {
+            DB::table('menus')->where('id', $existing->id)->update($payload);
+
+            return (int) $existing->id;
+        }
+
+        return (int) DB::table('menus')->insertGetId(array_merge($payload, [
+            'create_user' => 0,
+            'created_at' => $now,
+        ]));
+    }
+
+    /**
+     * 将菜单授权给管理员角色。
+     *
+     * @param array $menuIds
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/23
+     */
+    private function grantToAdminRoles(array $menuIds): void
+    {
+        $roleIds = DB::table('roles')
+            ->whereIn('code', ['super', 'admin'])
+            ->pluck('id')
+            ->all();
+
+        if (!$roleIds) {
+            return;
+        }
+
+        foreach ($roleIds as $roleId) {
+            foreach ($menuIds as $menuId) {
+                $exists = DB::table('role_menu')
+                    ->where('role_id', $roleId)
+                    ->where('menu_id', $menuId)
+                    ->exists();
+
+                if (!$exists) {
+                    DB::table('role_menu')->insert([
+                        'role_id' => $roleId,
+                        'menu_id' => $menuId,
+                    ]);
+                }
+            }
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,6 +20,7 @@ use App\Http\Controllers\Api\MiniProgram\HouseController;
 use App\Http\Controllers\Api\MiniProgram\ImageController;
 use App\Http\Controllers\Api\Admin\ServerPathController;
 use App\Http\Controllers\Api\Admin\InitModelController;
+use App\Http\Controllers\Api\Admin\PlatformScriptController;
 use App\Http\Controllers\Api\Admin\WorkDailyLogController;
 use App\Http\Controllers\Api\Admin\WorkDailyImageController;
 use App\Http\Controllers\Api\Admin\WorkDailyTagController;
@@ -56,6 +57,7 @@ use App\Models\MiniProgram\PhotoCategory;
 use App\Models\MiniProgram\Material;
 use App\Models\MiniProgram\House;
 use App\Models\Admin\ServerPath;
+use App\Models\Admin\PlatformScriptRun;
 use App\Models\Admin\InitModel;
 use App\Models\Admin\WorkDailyLog;
 use App\Models\Admin\WorkPlatform;
@@ -300,6 +302,16 @@ Route::name('api')->group(function () {
         Route::delete('init-model/{initModel}', [InitModelController::class, 'delete'])->name('init-model.delete');
         // 模型初始化转换
         Route::post('init-model/convert/{initModel}', [InitModelController::class, 'convert'])->name('init-model.convert');
+
+        // 平台脚本执行记录列表
+        Route::get('platform-script/index', [PlatformScriptController::class, 'index'])->name('platform-script.index')
+            ->middleware('filter.process:' . PlatformScriptRun::class);
+        // 平台脚本解析预览（不发送）
+        Route::post('platform-script/preview', [PlatformScriptController::class, 'preview'])->name('platform-script.preview');
+        // 平台脚本执行推送
+        Route::post('platform-script/run', [PlatformScriptController::class, 'run'])->name('platform-script.run');
+        // 平台脚本执行记录详情
+        Route::get('platform-script/{platformScriptRun}', [PlatformScriptController::class, 'info'])->name('platform-script.info');
 
         // 工作台仪表盘统计
         Route::get('dashboard/stats', [DashboardController::class, 'stats'])->name('dashboard.stats');

--- a/tests/Feature/Api/Admin/PlatformScriptControllerTest.php
+++ b/tests/Feature/Api/Admin/PlatformScriptControllerTest.php
@@ -1,0 +1,285 @@
+<?php
+
+use App\Models\Admin\PlatformScriptRun;
+use App\Models\User\User;
+use App\Services\Api\Admin\PlatformScript\Scripts\SinoloansComm3LoanScript;
+use App\Services\Api\Admin\PlatformScript\Support\SshRunner;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    Config::set('database.default', 'sqlite');
+    Config::set('database.connections.sqlite.database', ':memory:');
+    DB::purge('sqlite');
+    DB::setDefaultConnection('sqlite');
+
+    Schema::dropAllTables();
+
+    Schema::create('users', function (Blueprint $table) {
+        $table->id();
+        $table->string('username')->nullable();
+        $table->string('email')->nullable()->unique();
+        $table->string('phone')->nullable()->unique();
+        $table->string('openid')->nullable()->unique();
+        $table->string('unionid')->nullable()->unique();
+        $table->string('password')->nullable();
+        $table->timestamp('email_verified_at')->nullable();
+        $table->integer('status')->default(0);
+        $table->rememberToken();
+        $table->unsignedInteger('created_at')->default(0);
+        $table->integer('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+
+    Schema::create('roles', function (Blueprint $table) {
+        $table->id();
+        $table->string('name')->nullable();
+        $table->string('code')->nullable();
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+
+    Schema::create('user_role', function (Blueprint $table) {
+        $table->unsignedBigInteger('user_id')->default(0);
+        $table->unsignedBigInteger('role_id')->default(0);
+    });
+
+    Schema::create('platform_script_runs', function (Blueprint $table) {
+        $table->id();
+        $table->string('script_key', 64)->index();
+        $table->string('ordr_no', 40)->index();
+        $table->string('appl_id', 64)->default('');
+        $table->string('cntrct_no', 64)->default('');
+        $table->string('cntpr_nme', 128)->default('');
+        $table->string('cust_bank_acct_no', 64)->default('');
+        $table->string('cust_pay_amt', 32)->default('');
+        $table->string('actcpe_bchnw_id', 64)->default('');
+        $table->string('actope_bchnw_nme', 255)->default('');
+        $table->text('raw_text');
+        $table->text('request_data');
+        $table->longText('output');
+        $table->string('status', 16);
+        $table->text('error')->nullable();
+        $table->unsignedInteger('create_user')->default(0);
+        $table->unsignedInteger('created_at')->default(0);
+        $table->unsignedInteger('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+});
+
+it('解析预览返回字段与自增 ordrNo（无历史时以种子 +1）', function () {
+    $token = platformScriptLoginAsAdmin();
+
+    $response = $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->postJson('/api/platform-script/preview', [
+            'script_key' => SinoloansComm3LoanScript::KEY,
+            'text' => platformScriptSampleText(),
+        ]);
+
+    // 响应经 After 中间件包裹为 {code, data}，preview 裸数组落在 data 下（下划线键）
+    $response
+        ->assertOk()
+        ->assertJsonPath('data.fields.appl_id', 'SYBG5231803687502921728')
+        ->assertJsonPath('data.fields.cust_bank_acct_no', '6222620110099748528')
+        ->assertJsonPath('data.fields.cntrct_no', '202901331160999077200000001')
+        ->assertJsonPath('data.fields.cust_pay_amt', '10000')
+        ->assertJsonPath('data.fields.cntpr_nme', '王瑾诗')
+        ->assertJsonPath('data.fields.actcpe_bchnw_id', '01310207999')
+        ->assertJsonPath('data.fields.actope_bchnw_nme', '交通银行上海陕西南路支行')
+        ->assertJsonPath('data.ordr_no', 'SYBG0000000000000056');
+});
+
+it('ordrNo 基于历史最大值自增', function () {
+    $token = platformScriptLoginAsAdmin();
+    platformScriptCreateRun(['ordr_no' => 'SYBG0000000000000100']);
+    platformScriptCreateRun(['ordr_no' => 'SYBG0000000000000099']);
+
+    $response = $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->postJson('/api/platform-script/preview', [
+            'script_key' => SinoloansComm3LoanScript::KEY,
+            'text' => platformScriptSampleText(),
+        ]);
+
+    $response->assertOk()->assertJsonPath('data.ordr_no', 'SYBG0000000000000101');
+});
+
+it('缺少字段时预览返回 422', function () {
+    $token = platformScriptLoginAsAdmin();
+
+    $response = $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->postJson('/api/platform-script/preview', [
+            'script_key' => SinoloansComm3LoanScript::KEY,
+            'text' => "申请编号:SYBG5231803687502921728\n收款银行账户:6222620110099748528",
+        ]);
+
+    // After 中间件把校验异常也包成 HTTP 200 + body code=422
+    $response->assertOk()->assertJsonPath('code', 422);
+});
+
+it('执行推送落库并返回远端输出', function () {
+    $token = platformScriptLoginAsAdmin();
+
+    $this->mock(SshRunner::class, function ($mock) {
+        $mock->shouldReceive('run')
+            ->once()
+            ->andReturn(['output' => "请求报文: {...}\n响应报文: {\"code\":\"000000\"}\n", 'exit_status' => 0]);
+    });
+
+    $response = $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->postJson('/api/platform-script/run', [
+            'script_key' => SinoloansComm3LoanScript::KEY,
+            'text' => platformScriptSampleText(),
+        ]);
+
+    // run 走 BaseResource，字段会转成小驼峰
+    $response
+        ->assertOk()
+        ->assertJsonPath('data.status', 'success')
+        ->assertJsonPath('data.ordrNo', 'SYBG0000000000000056')
+        ->assertJsonPath('data.applId', 'SYBG5231803687502921728');
+
+    $run = PlatformScriptRun::query()->where('ordr_no', 'SYBG0000000000000056')->firstOrFail();
+
+    expect($run->status)->toBe('success')
+        ->and($run->output)->toContain('响应报文')
+        ->and(json_decode($run->request_data, true)['transferItemList'][0]['cntprNme'])->toBe('王瑾诗');
+});
+
+it('远端执行超时时落成 timeout 状态而非 success', function () {
+    $token = platformScriptLoginAsAdmin();
+
+    $this->mock(SshRunner::class, function ($mock) {
+        $mock->shouldReceive('run')
+            ->once()
+            ->andReturn(['output' => '', 'exit_status' => null, 'timed_out' => true]);
+    });
+
+    $response = $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->postJson('/api/platform-script/run', [
+            'script_key' => SinoloansComm3LoanScript::KEY,
+            'text' => platformScriptSampleText(),
+        ]);
+
+    $response->assertOk()->assertJsonPath('data.status', 'timeout');
+
+    $run = PlatformScriptRun::query()->where('ordr_no', 'SYBG0000000000000056')->firstOrFail();
+    expect($run->status)->toBe('timeout')
+        ->and($run->error)->toContain('超时');
+});
+
+it('payload 以 hex 编码且能被还原成请求数据', function () {
+    $script = new SinoloansComm3LoanScript([
+        'connection' => 'sinoloans',
+        'remote_path' => '/var/www/html/toocle/sinoloans',
+        'script_command' => 'php public/script.php controller=comm3-test action=loan',
+        'ordr_no_prefix' => 'SYBG',
+        'ordr_no_digits' => 16,
+        'ordr_no_seed' => 'SYBG0000000000000055',
+    ]);
+
+    expect($script->nextOrdrNo(null))->toBe('SYBG0000000000000056')
+        ->and($script->nextOrdrNo('SYBG0000000000000100'))->toBe('SYBG0000000000000101');
+
+    $fields = $script->parse(platformScriptSampleText());
+    $requestData = $script->buildRequestData($fields, 'SYBG0000000000000056');
+    $hex = bin2hex(json_encode($requestData, JSON_UNESCAPED_UNICODE));
+    $command = $script->command($hex);
+
+    // hex 只含 0-9a-f，命令行安全，且远端能 hex2bin 还原成同一份请求数据
+    expect($command)->toContain('payload=' . $hex)
+        ->and($hex)->toMatch('/^[0-9a-f]+$/')
+        ->and(json_decode(hex2bin($hex), true))->toBe($requestData);
+});
+
+/**
+ * sinoloans 放款测试样例粘贴文本。
+ *
+ * @return string
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/7/23
+ */
+function platformScriptSampleText(): string
+{
+    return <<<TEXT
+申请编号:SYBG5231803687502921728
+收款银行账户:6222620110099748528，
+合同号: 202901331160999077200000001,
+提款金额:10000，
+交易对手户名:王瑾诗，
+开户网点号: 01310207999，
+开户网点名:交通银行上海陕西南路支行
+TEXT;
+}
+
+/**
+ * 创建后台管理员登录令牌。
+ *
+ * @return string
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/7/23
+ */
+function platformScriptLoginAsAdmin(): string
+{
+    $admin = User::query()->create([
+        'username' => 'platform_script_admin',
+        'email' => 'platform-script-admin@example.com',
+        'phone' => '13800000021',
+        'password' => bcrypt('password'),
+        'status' => 1,
+    ]);
+
+    $roleId = DB::table('roles')->insertGetId([
+        'name' => '超级管理员',
+        'code' => 'super',
+        'deleted_at' => 0,
+    ]);
+
+    DB::table('user_role')->insert([
+        'user_id' => $admin->id,
+        'role_id' => $roleId,
+    ]);
+
+    return auth('api')->login($admin);
+}
+
+/**
+ * 创建平台脚本执行记录测试数据。
+ *
+ * @param array $attributes
+ * @return PlatformScriptRun
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/7/23
+ */
+function platformScriptCreateRun(array $attributes = []): PlatformScriptRun
+{
+    return PlatformScriptRun::query()->create(array_merge([
+        'script_key' => SinoloansComm3LoanScript::KEY,
+        'ordr_no' => 'SYBG0000000000000056',
+        'appl_id' => 'SYBG5231803687502921728',
+        'cntrct_no' => '202901331160999077200000001',
+        'cntpr_nme' => '王瑾诗',
+        'cust_bank_acct_no' => '6222620110099748528',
+        'cust_pay_amt' => '10000',
+        'actcpe_bchnw_id' => '01310207999',
+        'actope_bchnw_nme' => '交通银行上海陕西南路支行',
+        'raw_text' => platformScriptSampleText(),
+        'request_data' => '{}',
+        'output' => '',
+        'status' => 'success',
+        'error' => null,
+        'created_at' => time(),
+        'updated_at' => time(),
+        'deleted_at' => 0,
+    ], $attributes));
+}


### PR DESCRIPTION
## 背景
银行方常要求测试推送放款订单，此前需手动改 sinoloans 测试脚本的写死参数、手动 +1 ordrNo 再跑，繁琐易错。

## 改动
- 开发管理下新增「平台脚本」：粘贴银行推送文本 → 自动解析 7 字段 + 生成自增 ordrNo → 预览确认 → SSH 驱动 sinoloans 远端脚本执行并落库返回报文。
- payload 用 **hex** 编码（远端 CLI 以 `explode("=")` 拆参，规避 base64 的 `=` 补位被截断）。
- SSH 用 phpseclib3（密码 + 兼容老 ssh-rsa）；**超时落成 `timeout` 状态**而非伪装 success 空输出。
- 新增 `platform_script_runs` 表与开发管理菜单；表结构/Service 按 script_key 分发，为将来多脚本留位（本版仅 sinoloans-comm3-loan）。

## 测试
- Pest 6 项全通过（解析、ordrNo 自增、缺字段 422、执行落库、超时落态、hex 往返）。
- 远端实测：容器→sinoloans SSH 登录 OK；PHP 5.3.3 上 hex payload 解码 OK。

## 配套
- sinoloans_php 侧 `Comm3TestController::loanAction()` 接受 payload 参数（单独提交）。
- 需在后端 .env 配置 `SINOLOANS_SSH_*`（已在远端配置）。