### PR TITLE
设计管理新增商品图片提取

### DIFF
--- a/app/Exceptions/ProductImageExtractorException.php
+++ b/app/Exceptions/ProductImageExtractorException.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Exceptions;
+
+use Illuminate\Http\JsonResponse;
+use RuntimeException;
+
+class ProductImageExtractorException extends RuntimeException
+{
+    /**
+     * 初始化商品图片提取异常。
+     *
+     * @param string $message
+     * @param int $status
+     * @param int|null $remoteStatus
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function __construct(
+        string $message,
+        private readonly int $status = 422,
+        private readonly ?int $remoteStatus = null,
+    )
+    {
+        parent::__construct($message);
+    }
+
+    /**
+     * 获取远程资源响应状态。
+     *
+     * @return int|null
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function remoteStatus(): ?int
+    {
+        return $this->remoteStatus;
+    }
+
+    /**
+     * 渲染商品图片提取异常响应。
+     *
+     * @return JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function render(): JsonResponse
+    {
+        return response()->json(['message' => $this->getMessage()], $this->status);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/ProductImageExtractorController.php
+++ b/app/Http/Controllers/Api/Admin/ProductImageExtractorController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Api\Controller;
+use App\Http\Requests\Api\Admin\ProductImageExtractorRequest;
+use App\Services\Api\Admin\ProductImage\ProductImageExtractorService;
+use App\Services\Api\Admin\ProductImage\ProductImageZipService;
+use Illuminate\Http\JsonResponse;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+class ProductImageExtractorController extends Controller
+{
+    /**
+     * 初始化商品图片提取控制器。
+     *
+     * @param ProductImageExtractorService $extractorService
+     * @param ProductImageZipService $zipService
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function __construct(
+        private readonly ProductImageExtractorService $extractorService,
+        private readonly ProductImageZipService $zipService,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * 获取支持的商品平台。
+     *
+     * @return JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function platforms(): JsonResponse
+    {
+        return response()->json($this->extractorService->platforms());
+    }
+
+    /**
+     * 提取商品图片及元数据。
+     *
+     * @param ProductImageExtractorRequest $request
+     * @return JsonResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function extract(ProductImageExtractorRequest $request): JsonResponse
+    {
+        return response()->json($this->extractorService->extract(
+            $request->validated('platform'),
+            $request->validated('url'),
+        ));
+    }
+
+    /**
+     * 下载选中的商品图片压缩包。
+     *
+     * @param ProductImageExtractorRequest $request
+     * @return BinaryFileResponse
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function download(ProductImageExtractorRequest $request): BinaryFileResponse
+    {
+        $selection = $this->extractorService->selectForDownload(
+            $request->validated('platform'),
+            $request->validated('url'),
+            $request->validated('image_ids'),
+        );
+        $archive = $this->zipService->create(
+            $selection['adapter'],
+            $selection['product'],
+            $selection['images'],
+        );
+
+        return response()
+            ->download($archive['path'], $archive['name'], ['Content-Type' => 'application/zip'])
+            ->deleteFileAfterSend(true);
+    }
+}

--- a/app/Http/Requests/Api/Admin/ProductImageExtractorRequest.php
+++ b/app/Http/Requests/Api/Admin/ProductImageExtractorRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Requests\Api\Admin;
+
+use App\Http\Requests\Api\FormRequest;
+
+class ProductImageExtractorRequest extends FormRequest
+{
+    /**
+     * 获取商品图片提取接口校验规则。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function rules(): array
+    {
+        return match ($this->actionMethod()) {
+            'extract' => [
+                'platform' => ['required', 'string', 'max:50'],
+                'url' => ['required', 'string', 'max:2048', 'url', 'starts_with:https://'],
+            ],
+            'download' => [
+                'platform' => ['required', 'string', 'max:50'],
+                'url' => ['required', 'string', 'max:2048', 'url', 'starts_with:https://'],
+                'image_ids' => ['required', 'array', 'min:1'],
+                'image_ids.*' => ['required', 'string', 'size:64', 'distinct'],
+            ],
+            default => [],
+        };
+    }
+
+    /**
+     * 获取商品图片提取字段别名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function attributes(): array
+    {
+        return [
+            'platform' => '商品平台',
+            'url' => '商品地址',
+            'image_ids' => '图片',
+            'image_ids.*' => '图片 ID',
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -10,6 +10,8 @@ use App\Observers\Admin\WorkDailyLogObserver;
 use App\Observers\Admin\WorkDocObserver;
 use App\Observers\UserObserver;
 use App\Observers\Web\CommentObserver;
+use App\Services\Api\Admin\ProductImage\Contracts\HostResolver;
+use App\Services\Api\Admin\ProductImage\SystemHostResolver;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\ServiceProvider;
 
@@ -20,7 +22,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->bind(HostResolver::class, SystemHostResolver::class);
     }
 
     /**

--- a/app/Services/Api/Admin/ProductImage/Adapters/HonorProductImageAdapter.php
+++ b/app/Services/Api/Admin/ProductImage/Adapters/HonorProductImageAdapter.php
@@ -1,0 +1,428 @@
+<?php
+
+namespace App\Services\Api\Admin\ProductImage\Adapters;
+
+use App\Exceptions\ProductImageExtractorException;
+use App\Services\Api\Admin\ProductImage\Contracts\ProductImagePlatformAdapter;
+
+class HonorProductImageAdapter implements ProductImagePlatformAdapter
+{
+    /**
+     * 获取平台编码。
+     *
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function code(): string
+    {
+        return 'honor';
+    }
+
+    /**
+     * 获取平台名称。
+     *
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function name(): string
+    {
+        return (string) config('product-image-extractor.platforms.honor.name');
+    }
+
+    /**
+     * 判断是否支持指定商品地址。
+     *
+     * @param string $url
+     * @return bool
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function supports(string $url): bool
+    {
+        $parts = parse_url($url);
+        if (!is_array($parts)) {
+            return false;
+        }
+
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        $host = strtolower((string) ($parts['host'] ?? ''));
+        $path = (string) ($parts['path'] ?? '');
+        $pathPattern = (string) config('product-image-extractor.platforms.honor.page_path_pattern');
+
+        return $scheme === 'https'
+            && in_array($host, $this->pageHosts(), true)
+            && preg_match($pathPattern, $path) === 1;
+    }
+
+    /**
+     * 获取允许访问的商品页域名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function pageHosts(): array
+    {
+        return config('product-image-extractor.platforms.honor.page_hosts');
+    }
+
+    /**
+     * 获取允许访问的图片域名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function imageHosts(): array
+    {
+        return config('product-image-extractor.platforms.honor.image_hosts');
+    }
+
+    /**
+     * 校验商品页路径。
+     *
+     * @param string $url
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function validatePageUrl(string $url): void
+    {
+        if (!$this->supports($url)) {
+            throw new ProductImageExtractorException('请输入有效的荣耀商城商品地址');
+        }
+    }
+
+    /**
+     * 校验商品图片路径。
+     *
+     * @param string $url
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function validateImageUrl(string $url): void
+    {
+        $parts = parse_url($url);
+        if (!is_array($parts)) {
+            throw new ProductImageExtractorException('荣耀图片地址无效');
+        }
+
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        $host = strtolower((string) ($parts['host'] ?? ''));
+        $path = (string) ($parts['path'] ?? '');
+
+        if ($scheme !== 'https'
+            || !in_array($host, $this->imageHosts(), true)
+            || preg_match('#^/pimages/(?:product|display_auto)/[A-Za-z0-9._/-]+$#', $path) !== 1
+            || str_contains($path, '..')) {
+            throw new ProductImageExtractorException('荣耀图片地址无效');
+        }
+    }
+
+    /**
+     * 生成荣耀图片候选地址。
+     *
+     * 新商品通常保留无尺寸前缀原图，历史商品可能只保留 800×800 版本。
+     *
+     * @param string $url
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function imageCandidates(string $url): array
+    {
+        $this->validateImageUrl($url);
+        $parts = parse_url($url);
+        $path = (string) ($parts['path'] ?? '');
+        $directory = rtrim(dirname($path), '/');
+        $fileName = basename($path);
+        $fallbackUrl = sprintf(
+            'https://%s%s/800_800_%s',
+            (string) ($parts['host'] ?? ''),
+            $directory,
+            $fileName,
+        );
+        $this->validateImageUrl($fallbackUrl);
+
+        return array_values(array_unique([$url, $fallbackUrl]));
+    }
+
+    /**
+     * 解析商品页图片数据。
+     *
+     * @param string $sourceUrl
+     * @param string $html
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function extract(string $sourceUrl, string $html): array
+    {
+        $decodedHtml = html_entity_decode($html, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $productId = $this->requiredMatch('/ec\.product\.id\s*=\s*["\'](\d+)["\']\s*;/', $decodedHtml, '未找到商品 ID');
+        $productName = $this->requiredMatch('/ec\.product\.name\s*=\s*(["\'])(.*?)\1\s*;/s', $decodedHtml, '未找到商品名称', 2);
+        $attributes = $this->extractSkuAttributes($decodedHtml);
+        $posters = $this->extractPosters($decodedHtml);
+        $variants = $this->extractVariants($decodedHtml, $attributes, $posters);
+
+        if (empty($variants)) {
+            throw new ProductImageExtractorException('荣耀商品页结构已变更，未找到 SKU 图片');
+        }
+
+        return [
+            'platform' => [
+                'code' => $this->code(),
+                'name' => $this->name(),
+            ],
+            'product' => [
+                'id' => $productId,
+                'title' => trim($productName),
+                'sourceUrl' => $sourceUrl,
+            ],
+            'variants' => array_values($variants),
+        ];
+    }
+
+    /**
+     * 解析 SKU 属性。
+     *
+     * @param string $html
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function extractSkuAttributes(string $html): array
+    {
+        preg_match_all('/ec\.product\.setSkuAttrValueLst\([^,]+,\s*\{(.*?)\}\s*\)/s', $html, $matches);
+        $attributes = [];
+
+        foreach ($matches[1] as $object) {
+            $skuId = $this->objectProperty($object, 'skuId');
+            $attributeName = $this->objectProperty($object, 'attrName');
+            $attributeValue = $this->objectProperty($object, 'attrValue');
+            if ($skuId === null || $attributeName === null || $attributeValue === null) {
+                throw new ProductImageExtractorException('荣耀 SKU 属性结构无效');
+            }
+
+            $attributes[$skuId][$attributeName] = $attributeValue;
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * 解析 SKU 活动首图。
+     *
+     * @param string $html
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function extractPosters(string $html): array
+    {
+        preg_match_all('/prdPosters\.sbom\.push\(\{(.*?)\}\s*\)/s', $html, $matches);
+        $posters = [];
+
+        foreach ($matches[1] as $object) {
+            $skuCode = $this->objectProperty($object, 'sbomCode');
+            $name = $this->objectProperty($object, 'name');
+            $path = $this->objectProperty($object, 'path');
+            if ($skuCode === null || $name === null || $path === null) {
+                throw new ProductImageExtractorException('荣耀活动首图结构无效');
+            }
+
+            $posters[$skuCode] = [
+                'url' => $this->buildImageUrl($path, $name),
+                'thumbnailUrl' => $this->buildThumbnailUrl($path, $name),
+                'fileName' => $name,
+            ];
+        }
+
+        return $posters;
+    }
+
+    /**
+     * 解析商品 SKU 及轮播图。
+     *
+     * @param string $html
+     * @param array $attributes
+     * @param array $posters
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function extractVariants(string $html, array $attributes, array $posters): array
+    {
+        preg_match_all('/_groupPhotoList\s*=\s*\[\]\s*;(?<body>.*?)ec\.product\.setSku\s*\(\s*["\'](?<skuId>\d+)["\']\s*,\s*\{(?<sku>.*?)\}\s*\)\s*;/s', $html, $matches, PREG_SET_ORDER);
+        $variants = [];
+
+        foreach ($matches as $match) {
+            $skuId = $match['skuId'];
+            $skuCode = $this->objectProperty($match['sku'], 'code');
+            $variantName = $this->objectProperty($match['sku'], 'name');
+            $coverName = $this->objectProperty($match['sku'], 'photoName');
+            $coverPath = $this->objectProperty($match['sku'], 'photoPath');
+            if ($skuCode === null || $variantName === null || $coverName === null || $coverPath === null) {
+                throw new ProductImageExtractorException('荣耀 SKU 图片结构无效');
+            }
+
+            $images = [];
+            if (isset($posters[$skuCode])) {
+                $images[] = $this->imageData(
+                    $posters[$skuCode]['url'],
+                    $posters[$skuCode]['thumbnailUrl'],
+                    $posters[$skuCode]['fileName'],
+                    'poster',
+                    count($images) + 1,
+                );
+            }
+
+            $images[] = $this->imageData(
+                $this->buildImageUrl($coverPath, $coverName),
+                $this->buildThumbnailUrl($coverPath, $coverName),
+                $coverName,
+                'cover',
+                count($images) + 1,
+            );
+
+            preg_match_all('/_groupPhotoList\.push\s*\(\s*\{(.*?)\}\s*\)\s*;/s', $match['body'], $groupMatches);
+            foreach ($groupMatches[1] as $groupObject) {
+                $groupName = $this->objectProperty($groupObject, 'name');
+                $groupPath = $this->objectProperty($groupObject, 'path');
+                if ($groupName === null || $groupPath === null) {
+                    throw new ProductImageExtractorException('荣耀轮播图结构无效');
+                }
+
+                $images[] = $this->imageData(
+                    $this->buildImageUrl($groupPath, $groupName),
+                    $this->buildThumbnailUrl($groupPath, $groupName),
+                    $groupName,
+                    'gallery',
+                    count($images) + 1,
+                );
+            }
+
+            $variants[$skuId] = [
+                'id' => $skuId,
+                'skuId' => $skuId,
+                'skuCode' => $skuCode,
+                'name' => $variantName,
+                'attributes' => $attributes[$skuId] ?? [],
+                'images' => $images,
+            ];
+        }
+
+        return $variants;
+    }
+
+    /**
+     * 创建图片返回数据。
+     *
+     * @param string $url
+     * @param string $thumbnailUrl
+     * @param string $fileName
+     * @param string $role
+     * @param int $index
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function imageData(
+        string $url,
+        string $thumbnailUrl,
+        string $fileName,
+        string $role,
+        int $index,
+    ): array
+    {
+        return [
+            'index' => $index,
+            'role' => $role,
+            'url' => $url,
+            'thumbnailUrl' => $thumbnailUrl,
+            'fileName' => $fileName,
+        ];
+    }
+
+    /**
+     * 组装荣耀 CDN 缩略图地址。
+     *
+     * @param string $path
+     * @param string $name
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function buildThumbnailUrl(string $path, string $name): string
+    {
+        return $this->buildImageUrl($path, '800_800_' . $name);
+    }
+
+    /**
+     * 组装荣耀 CDN 原图地址。
+     *
+     * @param string $path
+     * @param string $name
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function buildImageUrl(string $path, string $name): string
+    {
+        if (!preg_match('/^[A-Za-z0-9._-]+$/', $name)) {
+            throw new ProductImageExtractorException('荣耀图片文件名无效');
+        }
+
+        $normalizedPath = '/' . trim($path, '/') . '/';
+        if (!preg_match('#^/(?:product|display_auto)/[A-Za-z0-9._/-]+/$#', $normalizedPath)
+            || str_contains($normalizedPath, '..')) {
+            throw new ProductImageExtractorException('荣耀图片路径无效');
+        }
+
+        $baseUrl = rtrim((string) config('product-image-extractor.platforms.honor.image_base_url'), '/');
+
+        return $baseUrl . $normalizedPath . $name;
+    }
+
+    /**
+     * 读取 JavaScript 对象的字符串属性。
+     *
+     * @param string $object
+     * @param string $property
+     * @return string|null
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function objectProperty(string $object, string $property): ?string
+    {
+        $pattern = '/(?:^|[,\s])' . preg_quote($property, '/') . '\s*:\s*(["\'])(.*?)\1/s';
+        if (preg_match($pattern, $object, $match) !== 1) {
+            return null;
+        }
+
+        return trim($match[2]);
+    }
+
+    /**
+     * 读取必须存在的页面字段。
+     *
+     * @param string $pattern
+     * @param string $subject
+     * @param string $message
+     * @param int $group
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function requiredMatch(string $pattern, string $subject, string $message, int $group = 1): string
+    {
+        if (preg_match($pattern, $subject, $match) !== 1 || !isset($match[$group])) {
+            throw new ProductImageExtractorException($message);
+        }
+
+        return $match[$group];
+    }
+}

--- a/app/Services/Api/Admin/ProductImage/Contracts/HostResolver.php
+++ b/app/Services/Api/Admin/ProductImage/Contracts/HostResolver.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Services\Api\Admin\ProductImage\Contracts;
+
+interface HostResolver
+{
+    /**
+     * 解析域名对应的全部 IP 地址。
+     *
+     * @param string $host
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function resolve(string $host): array;
+}

--- a/app/Services/Api/Admin/ProductImage/Contracts/ProductImagePlatformAdapter.php
+++ b/app/Services/Api/Admin/ProductImage/Contracts/ProductImagePlatformAdapter.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Services\Api\Admin\ProductImage\Contracts;
+
+interface ProductImagePlatformAdapter
+{
+    /**
+     * 获取平台编码。
+     *
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function code(): string;
+
+    /**
+     * 获取平台名称。
+     *
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function name(): string;
+
+    /**
+     * 判断是否支持指定商品地址。
+     *
+     * @param string $url
+     * @return bool
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function supports(string $url): bool;
+
+    /**
+     * 获取允许访问的商品页域名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function pageHosts(): array;
+
+    /**
+     * 获取允许访问的图片域名。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function imageHosts(): array;
+
+    /**
+     * 校验商品页路径。
+     *
+     * @param string $url
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function validatePageUrl(string $url): void;
+
+    /**
+     * 校验商品图片路径。
+     *
+     * @param string $url
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function validateImageUrl(string $url): void;
+
+    /**
+     * 按清晰度优先级生成可尝试的图片地址。
+     *
+     * 平台可以在页面原图不存在时提供受控的尺寸版本，服务层只会采用首个真实可访问的地址。
+     *
+     * @param string $url
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function imageCandidates(string $url): array;
+
+    /**
+     * 解析商品页图片数据。
+     *
+     * @param string $sourceUrl
+     * @param string $html
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function extract(string $sourceUrl, string $html): array;
+}

--- a/app/Services/Api/Admin/ProductImage/ProductImageExtractorService.php
+++ b/app/Services/Api/Admin/ProductImage/ProductImageExtractorService.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Services\Api\Admin\ProductImage;
+
+use App\Exceptions\ProductImageExtractorException;
+use App\Services\Api\Admin\ProductImage\Contracts\ProductImagePlatformAdapter;
+
+class ProductImageExtractorService
+{
+    /**
+     * 初始化商品图片提取服务。
+     *
+     * @param ProductImagePlatformRegistry $registry
+     * @param SafeRemoteFetcher $fetcher
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function __construct(
+        private readonly ProductImagePlatformRegistry $registry,
+        private readonly SafeRemoteFetcher $fetcher,
+    ) {
+    }
+
+    /**
+     * 获取支持的商品平台。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function platforms(): array
+    {
+        return $this->registry->platforms();
+    }
+
+    /**
+     * 提取商品图片及元数据。
+     *
+     * @param string $platform
+     * @param string $sourceUrl
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function extract(string $platform, string $sourceUrl): array
+    {
+        [$adapter, $result] = $this->parse($platform, $sourceUrl);
+
+        foreach ($result['variants'] as &$variant) {
+            foreach ($variant['images'] as &$image) {
+                $image['id'] = $this->imageId($variant['id'], $image);
+                $image = $this->resolveImage($adapter, $image);
+            }
+            unset($image);
+        }
+        unset($variant);
+
+        return $result;
+    }
+
+    /**
+     * 重新解析商品页并匹配下载图片。
+     *
+     * @param string $platform
+     * @param string $sourceUrl
+     * @param array $imageIds
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function selectForDownload(string $platform, string $sourceUrl, array $imageIds): array
+    {
+        $maxImages = (int) config('product-image-extractor.limits.images_per_zip');
+        if (count($imageIds) > $maxImages) {
+            throw new ProductImageExtractorException("单次最多下载 {$maxImages} 张图片", 413);
+        }
+
+        [$adapter, $result] = $this->parse($platform, $sourceUrl);
+        $requestedIds = array_fill_keys($imageIds, true);
+        $selected = [];
+
+        foreach ($result['variants'] as $variant) {
+            foreach ($variant['images'] as $image) {
+                $imageId = $this->imageId($variant['id'], $image);
+                if (!isset($requestedIds[$imageId])) {
+                    continue;
+                }
+
+                $image['id'] = $imageId;
+                $image = $this->resolveImage($adapter, $image);
+                $selected[] = [
+                    'variantId' => $variant['id'],
+                    'variantName' => $variant['name'],
+                    'image' => $image,
+                ];
+                unset($requestedIds[$imageId]);
+            }
+        }
+
+        if (!empty($requestedIds)) {
+            throw new ProductImageExtractorException('选中的图片已失效，请重新提取商品图片');
+        }
+
+        return [
+            'adapter' => $adapter,
+            'product' => $result['product'],
+            'images' => $selected,
+        ];
+    }
+
+    /**
+     * 获取并解析商品页。
+     *
+     * @param string $platform
+     * @param string $sourceUrl
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function parse(string $platform, string $sourceUrl): array
+    {
+        $adapter = $this->registry->adapterFor($platform, $sourceUrl);
+        $adapter->validatePageUrl($sourceUrl);
+        $html = $this->fetcher->fetchPage($adapter, $sourceUrl);
+        $result = $adapter->extract($sourceUrl, $html);
+
+        return [$adapter, $result];
+    }
+
+    /**
+     * 生成仅能匹配当前解析结果的图片 ID。
+     *
+     * @param string $variantId
+     * @param array $image
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function imageId(string $variantId, array $image): string
+    {
+        $payload = implode('|', [$variantId, $image['index'], $image['role'], $image['url']]);
+        $key = config('app.key');
+        if (!is_string($key) || $key === '') {
+            throw new \LogicException('APP_KEY 未配置，无法生成商品图片 ID');
+        }
+
+        return hash_hmac('sha256', $payload, $key);
+    }
+
+    /**
+     * 解析平台图片候选地址并附加响应元数据。
+     *
+     * @param ProductImagePlatformAdapter $adapter
+     * @param array $image
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function resolveImage(ProductImagePlatformAdapter $adapter, array $image): array
+    {
+        $resolved = $this->fetcher->probeFirstAvailableImage(
+            $adapter,
+            $adapter->imageCandidates($image['url']),
+        );
+
+        return array_merge($image, $resolved);
+    }
+}

--- a/app/Services/Api/Admin/ProductImage/ProductImagePlatformRegistry.php
+++ b/app/Services/Api/Admin/ProductImage/ProductImagePlatformRegistry.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Services\Api\Admin\ProductImage;
+
+use App\Exceptions\ProductImageExtractorException;
+use App\Services\Api\Admin\ProductImage\Contracts\ProductImagePlatformAdapter;
+use Illuminate\Contracts\Container\Container;
+
+class ProductImagePlatformRegistry
+{
+    /**
+     * 初始化商品图片平台注册表。
+     *
+     * @param Container $container
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function __construct(private readonly Container $container)
+    {
+    }
+
+    /**
+     * 获取已注册平台列表。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function platforms(): array
+    {
+        return array_map(
+            static fn (ProductImagePlatformAdapter $adapter) => [
+                'code' => $adapter->code(),
+                'name' => $adapter->name(),
+                'domains' => $adapter->pageHosts(),
+            ],
+            $this->adapters(),
+        );
+    }
+
+    /**
+     * 根据商品地址选择平台适配器。
+     *
+     * @param string $platform
+     * @param string $url
+     * @return ProductImagePlatformAdapter
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function adapterFor(string $platform, string $url): ProductImagePlatformAdapter
+    {
+        foreach ($this->adapters() as $adapter) {
+            if ($adapter->code() !== $platform) {
+                continue;
+            }
+
+            if (!$adapter->supports($url)) {
+                throw new ProductImageExtractorException('商品地址不属于选中的商品平台');
+            }
+
+            return $adapter;
+        }
+
+        throw new ProductImageExtractorException('暂不支持该商品平台');
+    }
+
+    /**
+     * 实例化全部平台适配器。
+     *
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function adapters(): array
+    {
+        $adapterClasses = config('product-image-extractor.adapters');
+        if (!is_array($adapterClasses)) {
+            throw new \LogicException('商品图片平台适配器配置无效');
+        }
+
+        return array_map(function (string $adapterClass): ProductImagePlatformAdapter {
+            $adapter = $this->container->make($adapterClass);
+            if (!$adapter instanceof ProductImagePlatformAdapter) {
+                throw new \LogicException("{$adapterClass} 未实现商品图片平台适配器接口");
+            }
+
+            return $adapter;
+        }, $adapterClasses);
+    }
+}

--- a/app/Services/Api/Admin/ProductImage/ProductImageZipService.php
+++ b/app/Services/Api/Admin/ProductImage/ProductImageZipService.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Services\Api\Admin\ProductImage;
+
+use App\Exceptions\ProductImageExtractorException;
+use App\Services\Api\Admin\ProductImage\Contracts\ProductImagePlatformAdapter;
+use ZipArchive;
+
+class ProductImageZipService
+{
+    /**
+     * 初始化商品图片压缩服务。
+     *
+     * @param SafeRemoteFetcher $fetcher
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function __construct(private readonly SafeRemoteFetcher $fetcher)
+    {
+    }
+
+    /**
+     * 下载商品图片并创建 ZIP 文件。
+     *
+     * @param ProductImagePlatformAdapter $adapter
+     * @param array $product
+     * @param array $images
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function create(ProductImagePlatformAdapter $adapter, array $product, array $images): array
+    {
+        if (empty($images)) {
+            throw new ProductImageExtractorException('请选择要下载的图片');
+        }
+
+        $temporaryRoot = storage_path('app/tmp/product-image-extractor');
+        $this->ensureDirectory($temporaryRoot);
+        $token = bin2hex(random_bytes(16));
+        $imageDirectory = $temporaryRoot . '/' . $token;
+        $zipPath = $temporaryRoot . '/' . $token . '.zip';
+        $this->ensureDirectory($imageDirectory);
+
+        $zip = new ZipArchive();
+        if ($zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+            rmdir($imageDirectory);
+            throw new \RuntimeException('无法创建商品图片压缩包');
+        }
+
+        $temporaryFiles = [];
+        $totalBytes = 0;
+        $zipLimit = (int) config('product-image-extractor.limits.zip_bytes');
+        $zipClosed = false;
+
+        try {
+            foreach ($images as $index => $selection) {
+                $temporaryPath = $imageDirectory . '/' . sprintf('%03d.bin', $index + 1);
+                $temporaryFiles[] = $temporaryPath;
+                $metadata = $this->fetcher->downloadImage(
+                    $adapter,
+                    $selection['image']['url'],
+                    $temporaryPath,
+                );
+                $totalBytes += $metadata['bytes'];
+                if ($totalBytes > $zipLimit) {
+                    throw new ProductImageExtractorException('压缩包图片总大小超过限制', 413);
+                }
+
+                $variantDirectory = $this->safeName($selection['variantName']) . '_' . $selection['variantId'];
+                $imageName = sprintf(
+                    '%02d_%s.%s',
+                    $selection['image']['index'],
+                    $selection['image']['role'],
+                    $metadata['extension'],
+                );
+
+                if (!$zip->addFile($temporaryPath, $variantDirectory . '/' . $imageName)) {
+                    throw new \RuntimeException('图片写入压缩包失败');
+                }
+            }
+
+            $closeResult = $zip->close();
+            $zipClosed = true;
+            if (!$closeResult) {
+                throw new \RuntimeException('商品图片压缩包关闭失败');
+            }
+        } catch (\Throwable $exception) {
+            if (!$zipClosed) {
+                $zip->close();
+            }
+            if (is_file($zipPath)) {
+                unlink($zipPath);
+            }
+            throw $exception;
+        } finally {
+            foreach ($temporaryFiles as $temporaryFile) {
+                if (is_file($temporaryFile)) {
+                    unlink($temporaryFile);
+                }
+            }
+            if (is_dir($imageDirectory)) {
+                rmdir($imageDirectory);
+            }
+        }
+
+        return [
+            'path' => $zipPath,
+            'name' => 'product-images-' . $product['id'] . '.zip',
+        ];
+    }
+
+    /**
+     * 创建商品图片临时目录。
+     *
+     * @param string $directory
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function ensureDirectory(string $directory): void
+    {
+        if (!is_dir($directory) && !mkdir($directory, 0700, true) && !is_dir($directory)) {
+            throw new \RuntimeException('无法创建商品图片临时目录');
+        }
+    }
+
+    /**
+     * 生成安全的 ZIP 目录名。
+     *
+     * @param string $name
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function safeName(string $name): string
+    {
+        $safeName = preg_replace('/[^\pL\pN._-]+/u', '_', trim($name));
+        if (!is_string($safeName) || $safeName === '') {
+            throw new ProductImageExtractorException('商品规格名称无法用于压缩包目录');
+        }
+
+        return $safeName;
+    }
+}

--- a/app/Services/Api/Admin/ProductImage/SafeRemoteFetcher.php
+++ b/app/Services/Api/Admin/ProductImage/SafeRemoteFetcher.php
@@ -1,0 +1,467 @@
+<?php
+
+namespace App\Services\Api\Admin\ProductImage;
+
+use App\Exceptions\ProductImageExtractorException;
+use App\Services\Api\Admin\ProductImage\Contracts\HostResolver;
+use App\Services\Api\Admin\ProductImage\Contracts\ProductImagePlatformAdapter;
+use GuzzleHttp\Psr7\UriResolver;
+use GuzzleHttp\Psr7\Utils;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\Factory;
+use Illuminate\Http\Client\Response;
+
+class SafeRemoteFetcher
+{
+    private const IMAGE_MIME_TYPES = [
+        'image/jpeg' => 'jpg',
+        'image/png' => 'png',
+        'image/webp' => 'webp',
+    ];
+
+    /**
+     * 初始化安全远程请求服务。
+     *
+     * @param Factory $http
+     * @param HostResolver $hostResolver
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function __construct(
+        private readonly Factory $http,
+        private readonly HostResolver $hostResolver,
+    ) {
+    }
+
+    /**
+     * 安全获取商品页 HTML。
+     *
+     * @param ProductImagePlatformAdapter $adapter
+     * @param string $url
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function fetchPage(ProductImagePlatformAdapter $adapter, string $url): string
+    {
+        [$response] = $this->sendWithRedirects($adapter, 'page', 'GET', $url);
+        $contentType = $this->normalizedContentType($response);
+        if ($contentType !== 'text/html') {
+            $this->closeResponse($response);
+            throw new ProductImageExtractorException('商品页返回的内容类型不是 HTML', 502);
+        }
+
+        $limit = (int) config('product-image-extractor.limits.page_bytes');
+        $contentLength = $this->contentLength($response);
+        if ($contentLength !== null && $contentLength > $limit) {
+            $this->closeResponse($response);
+            throw new ProductImageExtractorException('远程页面大小超过限制', 413);
+        }
+
+        return $this->readBody($response, $limit);
+    }
+
+    /**
+     * 安全读取图片响应头元数据。
+     *
+     * @param ProductImagePlatformAdapter $adapter
+     * @param string $url
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function probeImage(ProductImagePlatformAdapter $adapter, string $url): array
+    {
+        [$response] = $this->sendWithRedirects($adapter, 'image', 'HEAD', $url);
+        $contentType = $this->assertImageContentType($response);
+        $contentLength = $this->contentLength($response);
+        $limit = (int) config('product-image-extractor.limits.image_bytes');
+
+        if ($contentLength !== null && $contentLength > $limit) {
+            $this->closeResponse($response);
+            throw new ProductImageExtractorException('图片大小超过限制', 413);
+        }
+
+        $this->closeResponse($response);
+
+        return [
+            'mimeType' => $contentType,
+            'extension' => self::IMAGE_MIME_TYPES[$contentType],
+            'bytes' => $contentLength,
+        ];
+    }
+
+    /**
+     * 读取首个真实存在的图片候选地址。
+     *
+     * 只有明确的 404 才尝试下一个候选；连接失败、类型错误和大小超限会立即暴露。
+     *
+     * @param ProductImagePlatformAdapter $adapter
+     * @param array $urls
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function probeFirstAvailableImage(ProductImagePlatformAdapter $adapter, array $urls): array
+    {
+        if (empty($urls)) {
+            throw new \LogicException('商品图片候选地址不能为空');
+        }
+
+        foreach (array_values(array_unique($urls)) as $url) {
+            try {
+                return array_merge(['url' => $url], $this->probeImage($adapter, $url));
+            } catch (ProductImageExtractorException $exception) {
+                if ($exception->remoteStatus() !== 404) {
+                    throw $exception;
+                }
+            }
+        }
+
+        throw new ProductImageExtractorException('商品图片原图和可用尺寸版本均不存在', 502);
+    }
+
+    /**
+     * 安全下载图片到指定文件。
+     *
+     * @param ProductImagePlatformAdapter $adapter
+     * @param string $url
+     * @param string $destination
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function downloadImage(ProductImagePlatformAdapter $adapter, string $url, string $destination): array
+    {
+        [$response] = $this->sendWithRedirects($adapter, 'image', 'GET', $url);
+        $headerContentType = $this->assertImageContentType($response);
+        $contentLength = $this->contentLength($response);
+        $limit = (int) config('product-image-extractor.limits.image_bytes');
+
+        if ($contentLength !== null && $contentLength > $limit) {
+            $this->closeResponse($response);
+            throw new ProductImageExtractorException('图片大小超过限制', 413);
+        }
+
+        $bytes = $this->writeBody($response, $destination, $limit);
+        $finfo = new \finfo(FILEINFO_MIME_TYPE);
+        $actualContentType = $finfo->file($destination);
+        if (!is_string($actualContentType)
+            || !isset(self::IMAGE_MIME_TYPES[$actualContentType])
+            || $actualContentType !== $headerContentType) {
+            throw new ProductImageExtractorException('远程文件不是有效的商品图片', 502);
+        }
+
+        $size = getimagesize($destination);
+        if ($size === false) {
+            throw new ProductImageExtractorException('无法读取商品图片尺寸', 502);
+        }
+
+        return [
+            'mimeType' => $actualContentType,
+            'extension' => self::IMAGE_MIME_TYPES[$actualContentType],
+            'bytes' => $bytes,
+            'width' => $size[0],
+            'height' => $size[1],
+        ];
+    }
+
+    /**
+     * 逐次校验并跟随远程重定向。
+     *
+     * @param ProductImagePlatformAdapter $adapter
+     * @param string $resourceType
+     * @param string $method
+     * @param string $url
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function sendWithRedirects(
+        ProductImagePlatformAdapter $adapter,
+        string $resourceType,
+        string $method,
+        string $url,
+    ): array {
+        $currentUrl = $url;
+        $maxRedirects = (int) config('product-image-extractor.limits.redirects');
+
+        for ($redirects = 0; $redirects <= $maxRedirects; $redirects++) {
+            $allowedHosts = $resourceType === 'page' ? $adapter->pageHosts() : $adapter->imageHosts();
+            $resourceType === 'page'
+                ? $adapter->validatePageUrl($currentUrl)
+                : $adapter->validateImageUrl($currentUrl);
+
+            [$host, $port, $ip] = $this->validateAndResolveUrl($currentUrl, $allowedHosts);
+
+            try {
+                $response = $this->http
+                    ->withHeaders([
+                        'Accept' => $resourceType === 'page' ? 'text/html' : 'image/avif,image/webp,image/png,image/jpeg',
+                        'User-Agent' => 'Mozilla/5.0 (compatible; BlogProductImageExtractor/1.0)',
+                    ])
+                    ->withOptions([
+                        'allow_redirects' => false,
+                        'connect_timeout' => (int) config('product-image-extractor.limits.connect_timeout'),
+                        'timeout' => (int) config('product-image-extractor.limits.request_timeout'),
+                        'stream' => true,
+                        'verify' => true,
+                        'curl' => [
+                            CURLOPT_RESOLVE => [sprintf('%s:%d:%s', $host, $port, $this->curlResolveAddress($ip))],
+                        ],
+                    ])
+                    ->send($method, $currentUrl);
+            } catch (ConnectionException) {
+                throw new ProductImageExtractorException('远程资源连接失败', 502);
+            }
+
+            if ($this->isRedirect($response)) {
+                if ($redirects === $maxRedirects) {
+                    $this->closeResponse($response);
+                    throw new ProductImageExtractorException('远程资源重定向次数过多', 502);
+                }
+
+                $location = $response->header('Location');
+                $this->closeResponse($response);
+                if (!is_string($location) || trim($location) === '') {
+                    throw new ProductImageExtractorException('远程资源重定向地址无效', 502);
+                }
+
+                $currentUrl = (string) UriResolver::resolve(Utils::uriFor($currentUrl), Utils::uriFor($location));
+                continue;
+            }
+
+            if (!$response->successful()) {
+                $status = $response->status();
+                $this->closeResponse($response);
+                throw new ProductImageExtractorException("远程资源返回异常状态：{$status}", 502, $status);
+            }
+
+            return [$response, $currentUrl];
+        }
+
+        throw new ProductImageExtractorException('远程资源请求失败', 502);
+    }
+
+    /**
+     * 校验远程地址并锁定公网 IP。
+     *
+     * @param string $url
+     * @param array $allowedHosts
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function validateAndResolveUrl(string $url, array $allowedHosts): array
+    {
+        $parts = parse_url($url);
+        if (!is_array($parts)) {
+            throw new ProductImageExtractorException('远程资源地址无效');
+        }
+
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        $host = strtolower((string) ($parts['host'] ?? ''));
+        $port = isset($parts['port']) ? (int) $parts['port'] : 443;
+        if ($scheme !== 'https'
+            || $host === ''
+            || preg_match('/^[a-z0-9.-]+$/', $host) !== 1
+            || filter_var($host, FILTER_VALIDATE_IP) !== false
+            || !in_array($host, $allowedHosts, true)
+            || isset($parts['user'])
+            || isset($parts['pass'])
+            || isset($parts['fragment'])
+            || $port !== 443) {
+            throw new ProductImageExtractorException('远程资源地址不在允许范围内');
+        }
+
+        $addresses = $this->hostResolver->resolve($host);
+        if (empty($addresses)) {
+            throw new ProductImageExtractorException('远程资源域名无法解析', 502);
+        }
+
+        foreach ($addresses as $address) {
+            if (!$this->isPublicIp($address)) {
+                throw new ProductImageExtractorException('远程资源域名解析到非公网地址');
+            }
+        }
+
+        $ipv4 = array_values(array_filter($addresses, static fn (string $address) => filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false));
+        $ip = $ipv4[0] ?? $addresses[0];
+
+        return [$host, $port, $ip];
+    }
+
+    /**
+     * 判断 IP 是否为公网地址。
+     *
+     * @param string $address
+     * @return bool
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function isPublicIp(string $address): bool
+    {
+        if (str_starts_with(strtolower($address), '::ffff:')) {
+            return false;
+        }
+
+        return filter_var(
+            $address,
+            FILTER_VALIDATE_IP,
+            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE,
+        ) !== false;
+    }
+
+    /**
+     * 读取有大小上限的响应正文。
+     *
+     * @param Response $response
+     * @param int $limit
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function readBody(Response $response, int $limit): string
+    {
+        $stream = $response->toPsrResponse()->getBody();
+        $content = '';
+
+        while (!$stream->eof()) {
+            $content .= $stream->read(8192);
+            if (strlen($content) > $limit) {
+                $stream->close();
+                throw new ProductImageExtractorException('远程页面大小超过限制', 413);
+            }
+        }
+
+        $stream->close();
+
+        return $content;
+    }
+
+    /**
+     * 将有大小上限的响应正文写入文件。
+     *
+     * @param Response $response
+     * @param string $destination
+     * @param int $limit
+     * @return int
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function writeBody(Response $response, string $destination, int $limit): int
+    {
+        $target = fopen($destination, 'wb');
+        if ($target === false) {
+            $this->closeResponse($response);
+            throw new \RuntimeException('无法创建图片临时文件');
+        }
+
+        $stream = $response->toPsrResponse()->getBody();
+        $bytes = 0;
+
+        try {
+            while (!$stream->eof()) {
+                $chunk = $stream->read(8192);
+                $bytes += strlen($chunk);
+                if ($bytes > $limit) {
+                    throw new ProductImageExtractorException('图片大小超过限制', 413);
+                }
+                if ($chunk !== '' && fwrite($target, $chunk) === false) {
+                    throw new \RuntimeException('写入图片临时文件失败');
+                }
+            }
+        } finally {
+            fclose($target);
+            $stream->close();
+        }
+
+        return $bytes;
+    }
+
+    /**
+     * 校验图片响应类型。
+     *
+     * @param Response $response
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function assertImageContentType(Response $response): string
+    {
+        $contentType = $this->normalizedContentType($response);
+        if (!isset(self::IMAGE_MIME_TYPES[$contentType])) {
+            $this->closeResponse($response);
+            throw new ProductImageExtractorException('远程资源不是支持的图片类型', 502);
+        }
+
+        return $contentType;
+    }
+
+    /**
+     * 读取标准化响应类型。
+     *
+     * @param Response $response
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function normalizedContentType(Response $response): string
+    {
+        return strtolower(trim(explode(';', (string) $response->header('Content-Type'))[0]));
+    }
+
+    /**
+     * 读取响应内容长度。
+     *
+     * @param Response $response
+     * @return int|null
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function contentLength(Response $response): ?int
+    {
+        $value = $response->header('Content-Length');
+
+        return is_string($value) && ctype_digit($value) ? (int) $value : null;
+    }
+
+    /**
+     * 判断响应是否为重定向。
+     *
+     * @param Response $response
+     * @return bool
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function isRedirect(Response $response): bool
+    {
+        return in_array($response->status(), [301, 302, 303, 307, 308], true);
+    }
+
+    /**
+     * 关闭响应数据流。
+     *
+     * @param Response $response
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function closeResponse(Response $response): void
+    {
+        $response->toPsrResponse()->getBody()->close();
+    }
+
+    /**
+     * 格式化 curl DNS 锁定地址。
+     *
+     * @param string $ip
+     * @return string
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function curlResolveAddress(string $ip): string
+    {
+        return filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false ? "[{$ip}]" : $ip;
+    }
+}

--- a/app/Services/Api/Admin/ProductImage/SystemHostResolver.php
+++ b/app/Services/Api/Admin/ProductImage/SystemHostResolver.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Services\Api\Admin\ProductImage;
+
+use App\Services\Api\Admin\ProductImage\Contracts\HostResolver;
+
+class SystemHostResolver implements HostResolver
+{
+    /**
+     * 解析域名对应的全部 IP 地址。
+     *
+     * @param string $host
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function resolve(string $host): array
+    {
+        return $this->resolveHost($host, 0, []);
+    }
+
+    /**
+     * 递归解析 CNAME 链上的 A 和 AAAA 记录。
+     *
+     * @param string $host
+     * @param int $depth
+     * @param array $visited
+     * @return array
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function resolveHost(string $host, int $depth, array $visited): array
+    {
+        if ($depth > 5 || isset($visited[$host])) {
+            return [];
+        }
+
+        $visited[$host] = true;
+        $records = dns_get_record($host, DNS_A | DNS_AAAA | DNS_CNAME);
+        if ($records === false) {
+            return [];
+        }
+
+        $addresses = [];
+        $canonicalHosts = [];
+        foreach ($records as $record) {
+            if (isset($record['ip'])) {
+                $addresses[] = $record['ip'];
+            }
+            if (isset($record['ipv6'])) {
+                $addresses[] = $record['ipv6'];
+            }
+            if (($record['type'] ?? null) === 'CNAME' && isset($record['target'])) {
+                $canonicalHosts[] = rtrim(strtolower($record['target']), '.');
+            }
+        }
+
+        foreach (array_unique($canonicalHosts) as $canonicalHost) {
+            $addresses = array_merge($addresses, $this->resolveHost($canonicalHost, $depth + 1, $visited));
+        }
+
+        return array_values(array_unique($addresses));
+    }
+}

--- a/config/product-image-extractor.php
+++ b/config/product-image-extractor.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Services\Api\Admin\ProductImage\Adapters\HonorProductImageAdapter;
+
+return [
+    'adapters' => [
+        HonorProductImageAdapter::class,
+    ],
+
+    'limits' => [
+        'page_bytes' => 5 * 1024 * 1024,
+        'image_bytes' => 30 * 1024 * 1024,
+        'zip_bytes' => 500 * 1024 * 1024,
+        'images_per_zip' => 50,
+        'redirects' => 3,
+        'connect_timeout' => 5,
+        'request_timeout' => 20,
+    ],
+
+    'platforms' => [
+        'honor' => [
+            'name' => '荣耀商城',
+            'page_hosts' => [
+                'www.honor.com',
+            ],
+            'image_hosts' => [
+                'hshop.honorfile.com',
+            ],
+            'page_path_pattern' => '#^/cn/shop/product/\d+\.html$#',
+            'image_base_url' => 'https://hshop.honorfile.com/pimages',
+        ],
+    ],
+];

--- a/database/migrations/2026_07_20_000000_add_design_product_image_extractor_menu.php
+++ b/database/migrations/2026_07_20_000000_add_design_product_image_extractor_menu.php
@@ -1,0 +1,141 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class AddDesignProductImageExtractorMenu extends Migration
+{
+    /**
+     * 新增产品图片提取菜单。
+     *
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function up(): void
+    {
+        $designId = $this->upsertMenu('/design', [
+            'pid' => 0,
+            'title' => '设计管理',
+            'icon' => 'el-icon-picture-outline',
+            'component' => '',
+            'target' => '_self',
+            'permission' => '',
+            'type' => 0,
+            'status' => 1,
+            'hide' => 0,
+            'note' => '',
+            'sort' => 45,
+        ]);
+
+        $extractorId = $this->upsertMenu('/design/product-image-extractor', [
+            'pid' => $designId,
+            'title' => '商品图片提取',
+            'icon' => 'el-icon-download',
+            'component' => '/design/product-image-extractor',
+            'target' => '_self',
+            'permission' => 'design:productImageExtractor:view',
+            'type' => 0,
+            'status' => 1,
+            'hide' => 0,
+            'note' => '',
+            'sort' => 20,
+        ]);
+
+        $this->grantToAdminRoles([$designId, $extractorId]);
+    }
+
+    /**
+     * 删除产品图片提取菜单。
+     *
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    public function down(): void
+    {
+        $ids = DB::table('menus')
+            ->where('path', '/design/product-image-extractor')
+            ->pluck('id')
+            ->all();
+
+        if (!$ids) {
+            return;
+        }
+
+        DB::table('role_menu')->whereIn('menu_id', $ids)->delete();
+        DB::table('menus')->whereIn('id', $ids)->delete();
+    }
+
+    /**
+     * 新增或更新菜单。
+     *
+     * @param string $path
+     * @param array $data
+     * @return int
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function upsertMenu(string $path, array $data): int
+    {
+        $now = time();
+        $existing = DB::table('menus')
+            ->where('path', $path)
+            ->where('type', 0)
+            ->first();
+
+        $payload = array_merge($data, [
+            'path' => $path,
+            'update_user' => 0,
+            'updated_at' => $now,
+            'deleted_at' => 0,
+        ]);
+
+        if ($existing) {
+            DB::table('menus')->where('id', $existing->id)->update($payload);
+
+            return (int) $existing->id;
+        }
+
+        return (int) DB::table('menus')->insertGetId(array_merge($payload, [
+            'create_user' => 0,
+            'created_at' => $now,
+        ]));
+    }
+
+    /**
+     * 将菜单授权给管理员角色。
+     *
+     * @param array $menuIds
+     * @return void
+     * @author zhouxufeng <zxf@netsun.com>
+     * @date 2026/7/20
+     */
+    private function grantToAdminRoles(array $menuIds): void
+    {
+        $roleIds = DB::table('roles')
+            ->whereIn('code', ['super', 'admin'])
+            ->pluck('id')
+            ->all();
+
+        if (!$roleIds) {
+            return;
+        }
+
+        foreach ($roleIds as $roleId) {
+            foreach ($menuIds as $menuId) {
+                $exists = DB::table('role_menu')
+                    ->where('role_id', $roleId)
+                    ->where('menu_id', $menuId)
+                    ->exists();
+
+                if (!$exists) {
+                    DB::table('role_menu')->insert([
+                        'role_id' => $roleId,
+                        'menu_id' => $menuId,
+                    ]);
+                }
+            }
+        }
+    }
+}

--- a/database/seeders/MenuSeeder.php
+++ b/database/seeders/MenuSeeder.php
@@ -258,6 +258,7 @@ class MenuSeeder extends Seeder
                 'sort' => 45,
                 'children' => [
                     $this->module('图片处理', '/design/image-process', 'el-icon-picture-outline-round', 10, 'design:imageProcess:view', '图片处理'),
+                    $this->module('商品图片提取', '/design/product-image-extractor', 'el-icon-download', 20, 'design:productImageExtractor:view', '商品图片提取'),
                 ],
             ],
             [

--- a/routes/api.php
+++ b/routes/api.php
@@ -31,6 +31,7 @@ use App\Http\Controllers\Api\Admin\TodoItemController;
 use App\Http\Controllers\Api\Admin\PomoTaskController;
 use App\Http\Controllers\Api\Admin\PomoSettingController;
 use App\Http\Controllers\Api\Admin\PomoStatsController;
+use App\Http\Controllers\Api\Admin\ProductImageExtractorController;
 use App\Models\Admin\PomoTask;
 use App\Http\Controllers\Api\Admin\DashboardController;
 use App\Http\Controllers\Api\Web\ArticlesController;
@@ -312,6 +313,18 @@ Route::name('api')->group(function () {
         Route::post('platform-script/run', [PlatformScriptController::class, 'run'])->name('platform-script.run');
         // 平台脚本执行记录详情
         Route::get('platform-script/{platformScriptRun}', [PlatformScriptController::class, 'info'])->name('platform-script.info');
+
+        // 支持的商品图片平台
+        Route::get('design/product-image-extractor/platforms', [ProductImageExtractorController::class, 'platforms'])
+            ->name('design.product-image-extractor.platforms');
+        // 提取商品图片
+        Route::post('design/product-image-extractor/extract', [ProductImageExtractorController::class, 'extract'])
+            ->name('design.product-image-extractor.extract')
+            ->middleware('throttle:10,1');
+        // 下载商品图片压缩包
+        Route::post('design/product-image-extractor/download', [ProductImageExtractorController::class, 'download'])
+            ->name('design.product-image-extractor.download')
+            ->middleware('throttle:10,1');
 
         // 工作台仪表盘统计
         Route::get('dashboard/stats', [DashboardController::class, 'stats'])->name('dashboard.stats');

--- a/tests/Feature/Api/Admin/ProductImageExtractorControllerTest.php
+++ b/tests/Feature/Api/Admin/ProductImageExtractorControllerTest.php
@@ -1,0 +1,219 @@
+<?php
+
+use App\Models\User\User;
+use App\Services\Api\Admin\ProductImage\Contracts\HostResolver;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    Config::set('database.default', 'sqlite');
+    Config::set('database.connections.sqlite.database', ':memory:');
+    DB::purge('sqlite');
+    DB::setDefaultConnection('sqlite');
+
+    Schema::dropAllTables();
+    Schema::create('users', function (Blueprint $table) {
+        $table->id();
+        $table->string('username')->nullable();
+        $table->string('email')->nullable()->unique();
+        $table->string('phone')->nullable()->unique();
+        $table->string('openid')->nullable()->unique();
+        $table->string('unionid')->nullable()->unique();
+        $table->string('password')->nullable();
+        $table->timestamp('email_verified_at')->nullable();
+        $table->integer('status')->default(0);
+        $table->rememberToken();
+        $table->unsignedInteger('created_at')->default(0);
+        $table->integer('update_user')->default(0);
+        $table->unsignedInteger('updated_at')->default(0);
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+    Schema::create('roles', function (Blueprint $table) {
+        $table->id();
+        $table->string('name')->nullable();
+        $table->string('code')->nullable();
+        $table->unsignedInteger('deleted_at')->default(0);
+    });
+    Schema::create('user_role', function (Blueprint $table) {
+        $table->unsignedBigInteger('user_id')->default(0);
+        $table->unsignedBigInteger('role_id')->default(0);
+    });
+
+    $this->app->instance(HostResolver::class, new class implements HostResolver {
+        public function resolve(string $host): array
+        {
+            return ['1.1.1.1'];
+        }
+    });
+});
+
+it('返回已注册的商品图片平台', function () {
+    $token = productImageExtractorLoginAsAdmin();
+
+    $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->getJson('/api/design/product-image-extractor/platforms')
+        ->assertOk()
+        ->assertJsonPath('code', 0)
+        ->assertJsonPath('data.0.code', 'honor')
+        ->assertJsonPath('data.0.name', '荣耀商城')
+        ->assertJsonPath('data.0.domains.0', 'www.honor.com');
+});
+
+it('提取多颜色商品轮播图及响应头元数据', function () {
+    $token = productImageExtractorLoginAsAdmin();
+    productImageExtractorFakeHonorResponses();
+
+    $response = $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->postJson('/api/design/product-image-extractor/extract', [
+            'platform' => 'honor',
+            'url' => 'https://www.honor.com/cn/shop/product/90001.html',
+        ]);
+
+    $response
+        ->assertOk()
+        ->assertJsonPath('code', 0)
+        ->assertJsonPath('data.platform.code', 'honor')
+        ->assertJsonPath('data.variants.0.attributes.颜色', '棱镜黑')
+        ->assertJsonPath('data.product.title', '荣耀Earbuds耳夹式耳机Pro')
+        ->assertJsonPath('data.variants.0.skuId', '10001')
+        ->assertJsonPath('data.variants.0.images.0.index', 1)
+        ->assertJsonPath('data.variants.0.images.0.mimeType', 'image/png')
+        ->assertJsonPath('data.variants.0.images.0.bytes', strlen(productImageExtractorPng()))
+        ->assertJsonCount(4, 'data.variants.0.images')
+        ->assertJsonCount(3, 'data.variants.1.images');
+
+    expect($response->json('data.variants.0.images.0.id'))->toHaveLength(64);
+});
+
+it('服务端重新解析商品页并仅下载匹配的图片 ID', function () {
+    $token = productImageExtractorLoginAsAdmin();
+    productImageExtractorFakeHonorResponses();
+    $sourceUrl = 'https://www.honor.com/cn/shop/product/90001.html';
+
+    $extractResponse = $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->postJson('/api/design/product-image-extractor/extract', [
+            'platform' => 'honor',
+            'url' => $sourceUrl,
+        ]);
+    $imageId = $extractResponse->json('data.variants.0.images.0.id');
+
+    $downloadResponse = $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->postJson('/api/design/product-image-extractor/download', [
+            'platform' => 'honor',
+            'url' => $sourceUrl,
+            'imageIds' => [$imageId],
+        ]);
+
+    $downloadResponse
+        ->assertOk()
+        ->assertHeader('content-type', 'application/zip');
+
+    $binaryResponse = $downloadResponse->baseResponse;
+    $zipPath = $binaryResponse->getFile()->getPathname();
+    $zip = new \ZipArchive();
+
+    expect($zip->open($zipPath))
+        ->toBeTrue()
+        ->and($zip->numFiles)
+        ->toBe(1)
+        ->and($zip->getNameIndex(0))
+        ->toContain('10001/01_poster.png');
+
+    $zip->close();
+    unlink($zipPath);
+});
+
+it('拒绝伪造的图片 ID', function () {
+    $token = productImageExtractorLoginAsAdmin();
+    productImageExtractorFakeHonorResponses();
+
+    $this
+        ->withHeader('Authorization', "Bearer {$token}")
+        ->postJson('/api/design/product-image-extractor/download', [
+            'platform' => 'honor',
+            'url' => 'https://www.honor.com/cn/shop/product/90001.html',
+            'imageIds' => [str_repeat('a', 64)],
+        ])
+        ->assertOk()
+        ->assertJsonPath('code', 422)
+        ->assertJsonPath('msg', '选中的图片已失效，请重新提取商品图片');
+});
+
+/**
+ * 伪造荣耀商品页和图片响应。
+ *
+ * @return void
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/7/20
+ */
+function productImageExtractorFakeHonorResponses(): void
+{
+    $html = file_get_contents(base_path('tests/Fixtures/product-image/honor-two-variants.html'));
+    $png = productImageExtractorPng();
+
+    Http::fake(function (Request $request) use ($html, $png) {
+        if (str_contains($request->url(), '/cn/shop/product/90001.html')) {
+            return Http::response($html, 200, [
+                'Content-Type' => 'text/html; charset=UTF-8',
+                'Content-Length' => (string) strlen($html),
+            ]);
+        }
+
+        return Http::response($png, 200, [
+            'Content-Type' => 'image/png',
+            'Content-Length' => (string) strlen($png),
+        ]);
+    });
+}
+
+/**
+ * 获取有效的单像素 PNG 测试图片。
+ *
+ * @return string
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/7/20
+ */
+function productImageExtractorPng(): string
+{
+    return base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=', true);
+}
+
+/**
+ * 创建商品图片提取测试管理员令牌。
+ *
+ * @return string
+ * @author zhouxufeng <zxf@netsun.com>
+ * @date 2026/7/20
+ */
+function productImageExtractorLoginAsAdmin(): string
+{
+    $admin = User::query()->create([
+        'username' => 'product_image_admin',
+        'email' => 'product-image-admin@example.com',
+        'phone' => '13800000013',
+        'password' => bcrypt('password'),
+        'status' => 1,
+    ]);
+    $roleId = DB::table('roles')->insertGetId([
+        'name' => '超级管理员',
+        'code' => 'super',
+        'deleted_at' => 0,
+    ]);
+    DB::table('user_role')->insert([
+        'user_id' => $admin->id,
+        'role_id' => $roleId,
+    ]);
+
+    return auth('api')->login($admin);
+}

--- a/tests/Fixtures/product-image/honor-two-variants.html
+++ b/tests/Fixtures/product-image/honor-two-variants.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="zh">
+<body>
+<script>
+ec.product.skuAttrValueLst = [];
+ec.product.setSkuAttrValueLst(ec.product.skuAttrValueLst, { skuId : "10001", attrName : "&#x989c;&#x8272;", attrValue : "&#x68f1;&#x955c;&#x9ed1;" });
+ec.product.setSkuAttrValueLst(ec.product.skuAttrValueLst, { skuId : "10002", attrName : "&#x989c;&#x8272;", attrValue : "&#x73ab;&#x7470;&#x91d1;" });
+ec.product.id = "90001";
+ec.product.name = "&#x8363;&#x8000;Earbuds&#x8033;&#x5939;&#x5f0f;&#x8033;&#x673a;Pro";
+
+_groupPhotoList=[];
+_groupPhotoList.push({name:"BLACK-GALLERY-1mp.png", path:"&#x2f;product&#x2f;BLACK-GBOM&#x2f;group&#x2f;"});
+_groupPhotoList.push({name:"BLACK-GALLERY-2mp.png", path:"&#x2f;product&#x2f;BLACK-GBOM&#x2f;group&#x2f;"});
+prdPosters.sbom.push({sbomCode: 'SKU-BLACK', name: 'BLACK-POSTER.jpg', path: '&#x2f;display_auto&#x2f;SKU-BLACK&#x2f;'});
+prdPosters.sbom.push({sbomCode: 'SKU-GOLD', name: 'GOLD-POSTER.jpg', path: '&#x2f;display_auto&#x2f;SKU-GOLD&#x2f;'});
+ec.product.setSku("10001", { code : "SKU-BLACK", name : "&#x8363;&#x8000;Earbuds Pro &#x68f1;&#x955c;&#x9ed1;", photoName : "BLACK-COVERmp.png", photoPath : "&#x2f;product&#x2f;BLACK-GBOM&#x2f;" });
+
+_groupPhotoList=[];
+_groupPhotoList.push({name:"GOLD-GALLERY-1mp.png", path:"&#x2f;product&#x2f;GOLD-GBOM&#x2f;group&#x2f;"});
+ec.product.setSku("10002", { code : "SKU-GOLD", name : "&#x8363;&#x8000;Earbuds Pro &#x73ab;&#x7470;&#x91d1;", photoName : "GOLD-COVERmp.png", photoPath : "&#x2f;product&#x2f;GOLD-GBOM&#x2f;" });
+</script>
+</body>
+</html>

--- a/tests/Unit/Services/Api/Admin/ProductImage/HonorProductImageAdapterTest.php
+++ b/tests/Unit/Services/Api/Admin/ProductImage/HonorProductImageAdapterTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Services\Api\Admin\ProductImage\Adapters\HonorProductImageAdapter;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+it('解析多颜色 SKU 并保留轮播顺序', function () {
+    $html = file_get_contents(base_path('tests/Fixtures/product-image/honor-two-variants.html'));
+    $adapter = app(HonorProductImageAdapter::class);
+
+    $result = $adapter->extract('https://www.honor.com/cn/shop/product/90001.html', $html);
+
+    expect($result['platform'])
+        ->toEqual(['code' => 'honor', 'name' => '荣耀商城'])
+        ->and($result['product']['id'])
+        ->toBe('90001')
+        ->and($result['product']['title'])
+        ->toBe('荣耀Earbuds耳夹式耳机Pro')
+        ->and($result['variants'])
+        ->toHaveCount(2)
+        ->and($result['variants'][0]['attributes'])
+        ->toEqual(['颜色' => '棱镜黑'])
+        ->and(array_column($result['variants'][0]['images'], 'role'))
+        ->toEqual(['poster', 'cover', 'gallery', 'gallery'])
+        ->and($result['variants'][1]['attributes'])
+        ->toEqual(['颜色' => '玫瑰金'])
+        ->and(array_column($result['variants'][1]['images'], 'role'))
+        ->toEqual(['poster', 'cover', 'gallery']);
+});
+
+it('直接使用页面中的原图路径而不推导尺寸前缀', function () {
+    $html = file_get_contents(base_path('tests/Fixtures/product-image/honor-two-variants.html'));
+    $adapter = app(HonorProductImageAdapter::class);
+
+    $result = $adapter->extract('https://www.honor.com/cn/shop/product/90001.html', $html);
+    $urls = array_column($result['variants'][0]['images'], 'url');
+    $thumbnailUrls = array_column($result['variants'][0]['images'], 'thumbnailUrl');
+
+    expect($urls[0])
+        ->toBe('https://hshop.honorfile.com/pimages/display_auto/SKU-BLACK/BLACK-POSTER.jpg')
+        ->and($urls[1])
+        ->toBe('https://hshop.honorfile.com/pimages/product/BLACK-GBOM/BLACK-COVERmp.png')
+        ->and($urls[2])
+        ->toBe('https://hshop.honorfile.com/pimages/product/BLACK-GBOM/group/BLACK-GALLERY-1mp.png')
+        ->and($thumbnailUrls[2])
+        ->toBe('https://hshop.honorfile.com/pimages/product/BLACK-GBOM/group/800_800_BLACK-GALLERY-1mp.png')
+        ->and(implode('\n', $urls))
+        ->not->toContain('78_78_')
+        ->not->toContain('800_800_');
+});
+
+it('按原图优先并为历史商品提供 800 尺寸候选', function () {
+    $adapter = app(HonorProductImageAdapter::class);
+    $url = 'https://hshop.honorfile.com/pimages/product/6936520803927/group/IMAGE.png';
+
+    expect($adapter->imageCandidates($url))->toEqual([
+        $url,
+        'https://hshop.honorfile.com/pimages/product/6936520803927/group/800_800_IMAGE.png',
+    ]);
+});

--- a/tests/Unit/Services/Api/Admin/ProductImage/SafeRemoteFetcherTest.php
+++ b/tests/Unit/Services/Api/Admin/ProductImage/SafeRemoteFetcherTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use App\Exceptions\ProductImageExtractorException;
+use App\Services\Api\Admin\ProductImage\Adapters\HonorProductImageAdapter;
+use App\Services\Api\Admin\ProductImage\Contracts\HostResolver;
+use App\Services\Api\Admin\ProductImage\SafeRemoteFetcher;
+use Illuminate\Http\Client\Factory;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+it('拒绝解析到私有地址的白名单域名', function () {
+    $resolver = new class implements HostResolver {
+        public function resolve(string $host): array
+        {
+            return ['127.0.0.1'];
+        }
+    };
+    $fetcher = new SafeRemoteFetcher(app(Factory::class), $resolver);
+    $adapter = app(HonorProductImageAdapter::class);
+
+    expect(fn () => $fetcher->fetchPage($adapter, 'https://www.honor.com/cn/shop/product/90001.html'))
+        ->toThrow(ProductImageExtractorException::class, '远程资源域名解析到非公网地址');
+});
+
+it('拒绝白名单以外的商品域名', function () {
+    $adapter = app(HonorProductImageAdapter::class);
+
+    expect(fn () => $adapter->validatePageUrl('https://www.honor.com.example.test/cn/shop/product/90001.html'))
+        ->toThrow(ProductImageExtractorException::class, '请输入有效的荣耀商城商品地址');
+});
+
+it('逐次校验重定向地址并拒绝跳出白名单', function () {
+    $resolver = new class implements HostResolver {
+        public function resolve(string $host): array
+        {
+            return ['1.1.1.1'];
+        }
+    };
+    Http::fake([
+        'https://www.honor.com/*' => Http::response('', 302, [
+            'Location' => 'https://example.test/cn/shop/product/90001.html',
+        ]),
+    ]);
+    $fetcher = new SafeRemoteFetcher(app(Factory::class), $resolver);
+    $adapter = app(HonorProductImageAdapter::class);
+
+    expect(fn () => $fetcher->fetchPage($adapter, 'https://www.honor.com/cn/shop/product/90001.html'))
+        ->toThrow(ProductImageExtractorException::class, '请输入有效的荣耀商城商品地址');
+});
+
+it('仅在原图明确返回 404 时尝试平台尺寸候选', function () {
+    $resolver = new class implements HostResolver {
+        public function resolve(string $host): array
+        {
+            return ['1.1.1.1'];
+        }
+    };
+    $originalUrl = 'https://hshop.honorfile.com/pimages/product/10001/IMAGE.png';
+    $fallbackUrl = 'https://hshop.honorfile.com/pimages/product/10001/800_800_IMAGE.png';
+    Http::fake([
+        $originalUrl => Http::response('', 404, ['Content-Type' => 'text/html']),
+        $fallbackUrl => Http::response('', 200, [
+            'Content-Type' => 'image/png',
+            'Content-Length' => '123',
+        ]),
+    ]);
+    $fetcher = new SafeRemoteFetcher(app(Factory::class), $resolver);
+    $adapter = app(HonorProductImageAdapter::class);
+
+    expect($fetcher->probeFirstAvailableImage($adapter, [$originalUrl, $fallbackUrl]))
+        ->toEqual([
+            'url' => $fallbackUrl,
+            'mimeType' => 'image/png',
+            'extension' => 'png',
+            'bytes' => 123,
+        ]);
+});


### PR DESCRIPTION
## 改动
设计管理下新增「商品图片提取」：从商品平台页面（首版**荣耀商城**）提取商品图片与元数据，可打包 zip 下载。
- 适配器模式 `ProductImagePlatformAdapter` + `ProductImagePlatformRegistry`，`HostResolver` 抽象便于测试。
- `SafeRemoteFetcher` 限制白名单主机/大小/重定向，防 SSRF（拒绝解析到私有地址、跳出白名单等）。
- 新增 `design:productImageExtractor` 菜单与权限。

## 测试
远端 `./vendor/bin/sail pest` → `11 passed (48 assertions)`（Feature + Unit）。

> 说明：本功能为此前工作树中已有的未提交实现，本次原样纳入版本管理，未改动其逻辑。